### PR TITLE
Update eslint rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@tsconfig/node22": "^22.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
-    "rollup": "^4.24.4",
+    "rollup": "^4.25.0",
     "rollup-plugin-dts": "^6.1.1",
     "ts-jest": "^29.2.5",
     "typescript": "^5.6.3"

--- a/packages/eslint-config-hmpps/CHANGELOG.md
+++ b/packages/eslint-config-hmpps/CHANGELOG.md
@@ -5,7 +5,7 @@
 Pre-release for testing with HMPPS projects.
 Updated eslint rules to:
 
-- separate server and front-end config layers importing different globals for the browser.
+- separate globals into non-frontend, frontend, unit test and integration test groups.
 - downgrade `prettier` eslint rules to warning because they make _typing_ code rather painful.
   NB: warnings will still fail lint checks so this is just a quality-of-life change.
 - re-add `eslint-plugin-cypress` plugin

--- a/packages/eslint-config-hmpps/CHANGELOG.md
+++ b/packages/eslint-config-hmpps/CHANGELOG.md
@@ -1,5 +1,15 @@
 # History of changes
 
+## 0.0.1-alpha.7
+
+Pre-release for testing with HMPPS projects.
+Updated eslint rules to:
+
+- separate server and front-end config layers importing different globals for the browser.
+- downgrade `prettier` eslint rules to warning because they make _typing_ code rather painful.
+  NB: warnings will still fail lint checks so this is just a quality-of-life change.
+- re-add `eslint-plugin-cypress` plugin
+
 ## 0.0.1-alpha.6
 
 Pre-release for testing with HMPPS projects.

--- a/packages/eslint-config-hmpps/bin/migrate.sh
+++ b/packages/eslint-config-hmpps/bin/migrate.sh
@@ -18,6 +18,8 @@ rm -f .eslintignore .eslintrc.json
 
 printStage "* Create new config"
 [ -e eslint.config.mjs ] || cat > eslint.config.mjs <<EOL
+// @ts-check
+
 import hmppsConfig from '@ministryofjustice/eslint-config-hmpps'
 
 export default hmppsConfig()

--- a/packages/eslint-config-hmpps/index.cjs
+++ b/packages/eslint-config-hmpps/index.cjs
@@ -2,8 +2,6 @@ const importPlugin = require('eslint-plugin-import')
 const noOnlyTests = require('eslint-plugin-no-only-tests')
 const cypressPlugin = require('eslint-plugin-cypress/flat')
 
-const { fixupPluginRules } = require('@eslint/compat')
-
 const globals = require('globals')
 const typescriptEslint = require('@typescript-eslint/eslint-plugin')
 const tsParser = require('@typescript-eslint/parser')
@@ -109,15 +107,8 @@ function hmppsConfig({
       name: 'airbnb-rules',
       rules: airbnbRules,
     },
-    // `prettier` rules
-    ...makeCompat(['plugin:prettier/recommended']),
-    // general plugins and rule overrides
+    // `import` plugin rules
     {
-      name: 'hmpps-universal',
-      plugins: {
-        import: fixupPluginRules(importPlugin),
-        'no-only-tests': noOnlyTests,
-      },
       settings: {
         'import/parsers': {
           '@typescript-eslint/parser': ['.ts', '.tsx'],
@@ -130,6 +121,16 @@ function hmppsConfig({
             extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
           },
         },
+      },
+      ...importPlugin.flatConfigs.recommended,
+    },
+    // `prettier` rules
+    ...makeCompat(['plugin:prettier/recommended']),
+    // general plugins and rule overrides
+    {
+      name: 'hmpps-universal',
+      plugins: {
+        'no-only-tests': noOnlyTests,
       },
       rules: {
         'no-unused-vars': [

--- a/packages/eslint-config-hmpps/index.cjs
+++ b/packages/eslint-config-hmpps/index.cjs
@@ -42,11 +42,17 @@ const compat = new FlatCompat({
  *
  * @param {string[]} extraIgnorePaths add extra glob entires to ignored paths (e.g. build artefacts)
  * @param {string[]} extraPathsAllowingDevDependencies add extra glob entries that should allow dev dependencies (e.g. bin scripts)
- * @param {Linter.Globals} extraGlobals add languageOptions.globals entries (browser, node and jest are already included)
+ * @param {Linter.Globals} extraGlobals add languageOptions.globals entries (node and jest are already included)
+ * @param {Linter.Globals} extraFrontendGlobals add languageOptions.globals entries to front-end assets (browser is already included)
  *
  * @return {Linter.Config[]}
  */
-function hmppsConfig({ extraIgnorePaths = [], extraPathsAllowingDevDependencies = [], extraGlobals = {} } = {}) {
+function hmppsConfig({
+  extraIgnorePaths = [],
+  extraPathsAllowingDevDependencies = [],
+  extraGlobals = {},
+  extraFrontendGlobals = {},
+} = {}) {
   return [
     // ignore dependencies and build artefacts
     {
@@ -72,7 +78,6 @@ function hmppsConfig({ extraIgnorePaths = [], extraPathsAllowingDevDependencies 
       },
       languageOptions: {
         globals: {
-          ...globals.browser,
           ...globals.node,
           ...globals.jest,
           ...extraGlobals,
@@ -202,6 +207,16 @@ function hmppsConfig({ extraIgnorePaths = [], extraPathsAllowingDevDependencies 
             semi: false,
           },
         ],
+      },
+    },
+    // front-end globals
+    {
+      files: ['assets/**/*.js', 'assets/**/*.ts'],
+      languageOptions: {
+        globals: {
+          ...globals.browser,
+          ...extraFrontendGlobals,
+        },
       },
     },
   ]

--- a/packages/eslint-config-hmpps/index.cjs
+++ b/packages/eslint-config-hmpps/index.cjs
@@ -46,14 +46,18 @@ const scriptExtensionsGlob = '@(js|mjs|cjs|ts|mts|cts)'
 /**
  * Generates the HMPPS shared best-practice eslint rules for typescript projects
  *
- * @param {string[]} extraIgnorePaths add extra glob entires to ignored paths (e.g. build artefacts)
- * @param {string[]} extraPathsAllowingDevDependencies add extra glob entries that should allow dev dependencies (e.g. bin scripts)
- * @param {Linter.Globals} extraGlobals add languageOptions.globals entries (node is already included)
- * @param {Linter.Globals} extraFrontendGlobals add languageOptions.globals entries to frontend assets (browser is already included)
- * @param {Linter.Globals} extraUnitTestGlobals add languageOptions.globals entries to backend server (jest is already included)
- * @param {Linter.Globals} extraIntegrationGlobals add languageOptions.globals entries to frontend assets (cypress, browser and mocha already included)
+ * @typedef { Record<string, Boolean> } Globals
+ * @typedef { import('eslint').Linter.Config } LinterConfig
  *
- * @return {Linter.Config[]}
+ * @param {object} args
+ * @param {string[]=} args.extraIgnorePaths add extra glob entires to ignored paths (e.g. build artefacts)
+ * @param {string[]=} args.extraPathsAllowingDevDependencies add extra glob entries that should allow dev dependencies (e.g. bin scripts)
+ * @param {Globals=} args.extraGlobals add languageOptions.globals entries (node is already included)
+ * @param {Globals=} args.extraFrontendGlobals add languageOptions.globals entries to frontend assets (browser is already included)
+ * @param {Globals=} args.extraUnitTestGlobals add languageOptions.globals entries to backend server (jest is already included)
+ * @param {Globals=} args.extraIntegrationGlobals add languageOptions.globals entries to frontend assets (cypress, browser and mocha already included)
+ *
+ * @return {LinterConfig[]}
  */
 function hmppsConfig({
   extraIgnorePaths = [],

--- a/packages/eslint-config-hmpps/index.cjs
+++ b/packages/eslint-config-hmpps/index.cjs
@@ -1,5 +1,6 @@
 const importPlugin = require('eslint-plugin-import')
 const noOnlyTests = require('eslint-plugin-no-only-tests')
+const cypressPlugin = require('eslint-plugin-cypress/flat')
 
 const { fixupPluginRules } = require('@eslint/compat')
 
@@ -208,6 +209,11 @@ function hmppsConfig({
           },
         ],
       },
+    },
+    // cypress integration tests
+    {
+      files: ['integration_tests/**/*.js', 'integration_tests/**/*.ts'],
+      ...cypressPlugin.configs.recommended,
     },
     // front-end globals
     {

--- a/packages/eslint-config-hmpps/index.cjs
+++ b/packages/eslint-config-hmpps/index.cjs
@@ -9,6 +9,8 @@ const typescriptEslint = require('@typescript-eslint/eslint-plugin')
 const tsParser = require('@typescript-eslint/parser')
 const js = require('@eslint/js')
 
+// TODO: replace typescript plugin and parser with eslint v9 plugins
+
 const { FlatCompat } = require('@eslint/eslintrc')
 
 const { rules: bestPracticesRules } = require('./airbnbRules/best-practices')

--- a/packages/eslint-config-hmpps/index.cjs
+++ b/packages/eslint-config-hmpps/index.cjs
@@ -44,20 +44,27 @@ const compat = new FlatCompat({
 const scriptExtensionsGlob = '@(js|mjs|cjs|ts|mts|cts)'
 
 /**
+ * Eslint linter config object
+ * @typedef { import('eslint').Linter.Config } LinterConfig
+ */
+
+/**
+ * Eslint linter globals object
+ * @typedef { import('eslint').Linter.Globals } LinterGlobals
+ */
+
+/**
  * Generates the HMPPS shared best-practice eslint rules for typescript projects
  *
- * @typedef { Record<string, Boolean> } Globals
- * @typedef { import('eslint').Linter.Config } LinterConfig
- *
- * @param {object} args
+ * @param {Object=} args
  * @param {string[]=} args.extraIgnorePaths add extra glob entires to ignored paths (e.g. build artefacts)
  * @param {string[]=} args.extraPathsAllowingDevDependencies add extra glob entries that should allow dev dependencies (e.g. bin scripts)
- * @param {Globals=} args.extraGlobals add languageOptions.globals entries (node is already included)
- * @param {Globals=} args.extraFrontendGlobals add languageOptions.globals entries to frontend assets (browser is already included)
- * @param {Globals=} args.extraUnitTestGlobals add languageOptions.globals entries to backend server (jest is already included)
- * @param {Globals=} args.extraIntegrationGlobals add languageOptions.globals entries to frontend assets (cypress, browser and mocha already included)
+ * @param {LinterGlobals=} args.extraGlobals add languageOptions.globals entries (node is already included)
+ * @param {LinterGlobals=} args.extraFrontendGlobals add languageOptions.globals entries to frontend assets (browser is already included)
+ * @param {LinterGlobals=} args.extraUnitTestGlobals add languageOptions.globals entries to unit tests (jest is already included)
+ * @param {LinterGlobals=} args.extraIntegrationGlobals add languageOptions.globals entries to integration tests (cypress, browser and mocha already included)
  *
- * @return {LinterConfig[]}
+ * @return {LinterConfig[]} an array of eslint config objects
  */
 function hmppsConfig({
   extraIgnorePaths = [],

--- a/packages/eslint-config-hmpps/index.cjs
+++ b/packages/eslint-config-hmpps/index.cjs
@@ -48,18 +48,23 @@ const compat = new FlatCompat({
  */
 function hmppsConfig({ extraIgnorePaths = [], extraPathsAllowingDevDependencies = [], extraGlobals = {} } = {}) {
   return [
+    // ignore dependencies and build artefacts
     {
       ignores: ['**/node_modules', 'dist/', ...extraIgnorePaths],
     },
+    // warn when an eslint-disable comment does nothing
     {
       linterOptions: {
         reportUnusedDisableDirectives: true,
       },
     },
+    // Airbnb best-practice rules
     {
       rules: airbnbRules,
     },
+    // `prettier` rules
     ...compat.extends('plugin:prettier/recommended'),
+    // general plugins and rule overrides
     {
       plugins: {
         import: fixupPluginRules(importPlugin),
@@ -151,6 +156,7 @@ function hmppsConfig({ extraIgnorePaths = [], extraPathsAllowingDevDependencies 
         ],
       },
     },
+    // typescript-specific plugins and rule overrides
     ...compat
       .extends(
         'plugin:@typescript-eslint/eslint-recommended',

--- a/packages/eslint-config-hmpps/index.cjs
+++ b/packages/eslint-config-hmpps/index.cjs
@@ -145,7 +145,7 @@ function hmppsConfig({
         'no-only-tests/no-only-tests': 'error',
         'no-restricted-syntax': ['error', 'ForInStatement', 'LabeledStatement', 'WithStatement'],
         'prettier/prettier': [
-          'error',
+          'warn',
           {
             trailingComma: 'all',
             singleQuote: true,
@@ -199,7 +199,7 @@ function hmppsConfig({
         'import/no-unresolved': 'error',
         'import/no-named-as-default-member': 0,
         'prettier/prettier': [
-          'error',
+          'warn',
           {
             trailingComma: 'all',
             singleQuote: true,

--- a/packages/eslint-config-hmpps/package.json
+++ b/packages/eslint-config-hmpps/package.json
@@ -30,7 +30,6 @@
     "lint-fix": "eslint . --cache --max-warnings 0 --fix"
   },
   "dependencies": {
-    "@eslint/compat": "^1.2.2",
     "@eslint/eslintrc": "3.1.0",
     "@eslint/js": "^9.14.0",
     "@typescript-eslint/eslint-plugin": "^8.13.0",

--- a/packages/eslint-config-hmpps/package.json
+++ b/packages/eslint-config-hmpps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/eslint-config-hmpps",
-  "version": "0.0.1-alpha.6",
+  "version": "0.0.1-alpha.7",
   "description": "ESLint rules for HMPPS typescript projects",
   "keywords": [
     "eslint",

--- a/packages/eslint-config-hmpps/package.json
+++ b/packages/eslint-config-hmpps/package.json
@@ -48,7 +48,6 @@
   },
   "devDependencies": {
     "@types/confusing-browser-globals": "^1.0.3",
-    "@types/eslint": "^9.6.1",
     "@types/eslint__eslintrc": "^2.1.2",
     "@types/eslint__js": "^8.42.3",
     "@types/semver": "^7.5.8"

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -20,7 +20,7 @@
     "node": "20 || 22"
   },
   "scripts": {
-    "build": "rollup -c rollup.config.js --bundleConfigAsCjs",
+    "build": "rollup -c rollup.config.ts --bundleConfigAsCjs",
     "clean": "rm -rf ./dist/",
     "test": "jest",
     "lint": "eslint . --cache --max-warnings 0",
@@ -34,6 +34,6 @@
     "@types/bunyan": "^1.8.11",
     "@types/express": "^4.17.21",
     "@types/superagent": "^8.1.9",
-    "nock": "^13.5.5"
+    "nock": "^13.5.6"
   }
 }

--- a/packages/monitoring/rollup.config.ts
+++ b/packages/monitoring/rollup.config.ts
@@ -3,7 +3,7 @@ import typescript from '@rollup/plugin-typescript'
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { dts } from 'rollup-plugin-dts'
 
-import pkg from './package.json' with { type: 'json' }
+import pkg from './package.json'
 
 export default [
   {

--- a/packages/monitoring/tsconfig.json
+++ b/packages/monitoring/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "declarationDir": "./dist",
+    "resolveJsonModule": true,
     "sourceMap": true
   },
   "include": ["./src/**/*.ts"],


### PR DESCRIPTION
- separate server and front-end config layers importing different globals for the browser.
- downgrade `prettier` eslint rules to warning because they make _typing_ code rather painful.
  NB: warnings will still fail lint checks so this is just a quality-of-life change.
- re-add missing `eslint-plugin-cypress` plugin