### PR TITLE
Test build step during regular CI runs

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -37,6 +37,8 @@ jobs:
         run: npm install
       - name: Run unit tests
         run: npm test
+      - name: Test build step
+        run: npm run build
 
   lint:
     name: Run linting checks


### PR DESCRIPTION
…so that we know the release step is more likely to succeed (eg. test changes rollup config)