### PR TITLE
Fix endpointComponentChecks and adding script

### DIFF
--- a/packages/eslint-config-hmpps/README.md
+++ b/packages/eslint-config-hmpps/README.md
@@ -15,7 +15,6 @@ New projects based on this template will automatically adopt this package.
 
 ### Migrating existing projects
 
-
 #### Automatically installing the library
 
 The package will self install by running via npx:

--- a/packages/monitoring/README.md
+++ b/packages/monitoring/README.md
@@ -16,6 +16,24 @@ New projects based on this template will automatically adopt this package.
 
 ### Migrating existing projects
 
+#### Automatically installing the library
+
+The package will self install by running via npx:
+`npx @ministryofjustice/hmpps-monitoring`
+
+How successful this will be is dependent on how similar the codebase is to the current HEAD of the template project.
+
+The final step of the installation script prints instructions on how to manually apply a few changes:
+
+* Decorating `config.ts` to add `healthPath` declarations to each api definition.
+  * Spring boot applications usually expose their health endpoints on `/health/ping` but this may vary and you will need to check this for each api.  
+* Ensure that this has not removed any existing health checks
+  * This migration only attempts to ensure you have coverage for configured APIs
+* Ensure that you have integration test coverage for any newly added health checks
+  * Stubs will need to be added for any previously missing endpoints
+
+The generated changes will need to be reviewed carefully! 
+
 #### Manually installing the library
 
 The template project was migrated as part of [pull request 479](https://github.com/ministryofjustice/hmpps-template-typescript/pull/479),

--- a/packages/monitoring/bin/migrate.sh
+++ b/packages/monitoring/bin/migrate.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! [ -f ./package.json ]; then
+  printf "\x1b[1;31mNot in a node project! exiting...\x1b[0m\n"
+  exit 1
+fi
+
+printStage() {
+  printf "\x1b[1;97m$1\x1b[0m\n"
+}
+
+printStage "Migrating project:"
+
+printStage "* Deleting old health check files"
+rm -f \
+  server/data/healthCheck.ts \
+  server/data/healthCheck.test.ts \
+  server/services/healthCheck.ts \
+  server/services/healthCheck.test.ts
+
+printStage "* Ensuring productId is mandatory in ApplicationInfo"
+sed -i '' "s/productId?/productId/g" server/applicationInfo.ts
+
+printStage "* Replace healthcheck middleware"
+cat > server/middleware/setUpHealthChecks.ts <<EOL
+import express, { Router } from 'express'
+
+import { monitoringMiddleware, endpointComponent } from '@ministryofjustice/hmpps-monitoring'
+import type { ApplicationInfo } from '../applicationInfo'
+import logger from '../../logger'
+import config from '../config'
+
+export default function setUpHealthChecks(applicationInfo: ApplicationInfo): Router {
+  const router = express.Router()
+
+  const apiConfig = Object.entries(config.apis)
+
+  const middleware = monitoringMiddleware({
+    applicationInfo,
+    healthComponents: apiConfig.map(([name, options]) => endpointComponent(logger, name, options)),
+  })
+
+  router.get('/health', middleware.health)
+  router.get('/info', middleware.info)
+  router.get('/ping', middleware.ping)
+
+  return router
+}
+EOL
+
+printStage "* Installing new library"
+npm install @ministryofjustice/hmpps-monitoring
+
+printStage "* Manual steps"
+echo "
+ Now:   
+- Add 'healthPath' keys to each API config in 'config.ts' for the path where the health check endpoint exists.
+- Check health check coverage - this only attempts to hook up health checks for APIs defined in config, any custom health checks will need to be re-added.
+- Run integration tests see if you need to add missing stubbing for APIs that previously had no health checks.
+"

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-monitoring",
-  "version": "0.0.1-alpha.4",
+  "version": "0.0.1-alpha.5",
   "description": "Retrieve and display health and status information from external services and internal components",
   "author": "hmpps-developers",
   "license": "MIT",
@@ -9,6 +9,7 @@
     "type": "git",
     "url": "https://github.com/ministryofjustice/hmpps-typescript-lib.git"
   },
+  "bin": "./bin/migrate.sh",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",

--- a/packages/monitoring/src/main/components/EndpointComponent.test.ts
+++ b/packages/monitoring/src/main/components/EndpointComponent.test.ts
@@ -14,13 +14,13 @@ describe('EndpointComponent', () => {
   } as unknown as jest.Mocked<Console>
 
   beforeEach(() => {
-    nock = createTestNock('get')
+    nock = createTestNock({ method: 'get', baseUrl: 'https://test.local', path: '/some-path' })
     endpointComponentOptions = {
       enabled: true,
       retries: 2,
       timeout: 1000,
-      url: nock.url,
-      healthPath: '',
+      url: nock.baseUrl,
+      healthPath: nock.uniquePath,
     }
     jest.resetAllMocks()
   })
@@ -76,6 +76,7 @@ describe('EndpointComponent', () => {
     const logMessages = messages.mock.calls.map(call => call[0])
 
     expect(logMessages).toStrictEqual([
+      `Monitoring health of external service '${componentName}' on: '${nock.fullUrl}'`,
       `Attempting to get health of external service '${componentName}', received response: 500`,
       `Attempting to get health of external service '${componentName}', received response: 500`,
       `Failed getting health of external service '${componentName}'`,

--- a/packages/monitoring/src/test/utils.ts
+++ b/packages/monitoring/src/test/utils.ts
@@ -1,15 +1,22 @@
 import nock from 'nock'
 
-export const createTestNock = (
-  method: 'get' | 'post' | 'put' | 'delete' | 'patch',
-  baseUrl: string = 'https://test.local',
-) => {
-  const uniquePath = `/test/${Math.random().toString(36).substring(2, 8)}`
+export const createTestNock = ({
+  method,
+  baseUrl,
+  path,
+}: {
+  method: 'get' | 'post' | 'put' | 'delete' | 'patch'
+  baseUrl: string
+  path: string
+}) => {
   const scope = nock(baseUrl)
+  const uniquePath = `${path}/${Math.random().toString(36).substring(2, 8)}`
 
   return {
     scope: scope.persist()[method](uniquePath),
-    url: `${baseUrl}${uniquePath}`,
+    fullUrl: `${baseUrl}${uniquePath}`,
+    uniquePath,
+    baseUrl,
     done: () => scope.done(),
   }
 }


### PR DESCRIPTION
* There was an issue with the new healthPath key not actually being used!
  * This fixes that and ensures we have test coverage
  * Add a log message at start up to notify of health check registration

* Adding a script to make it easier to apply the plugin
  * This will be more successful with applications that have not evolved away from the template project
  * Updating docs