### PR TITLE
Alee/fix api response structure

### DIFF
--- a/packages/monitoring/README.md
+++ b/packages/monitoring/README.md
@@ -58,23 +58,27 @@ To configure the middleware it needs to be initialised with [ApplicationInfo](ht
 - This should match the `ApplicationInfo` type that comes with recent versions of the template project.
 - One recent change is that `productId` is now mandatory and should be configured - reach out to `#ask-hmpps-sre-team` about this on slack.
 
-It also requires an array of `EndpointComponent`s which represent each API that this service calls.
+It also requires an array of `HealthComponent`s which represent components that this service relies on.
 By including these then things like pingdom and the health monitor will correctly record when your application is healthy.
+
+### EndpointHealthComponents
+
+The library provides an implementation of `HealthComponent`, `EndpointHealthComponent`, which is used to track the health of APIs that this service relies on. 
 
 These require:
 
 - An instance of the logger that your application uses
 - The name of your API that you rely on
-- [EndpointComponentOptions](https://github.com/ministryofjustice/hmpps-typescript-lib/blob/dd4da10195ec6701fa3120a8935ffac679701cbd/packages/monitoring/src/main/types/EndpointComponentOptions.ts#L3)
+- `EndpointHealthComponentOptions`
 
-Dependending on how your Api Configuration is organised in `config.ts`it might be possible to automatically map this to the correct form required by the `endpointComponent` as demonstrated below:
+Dependending on how your Api Configuration is organised in `config.ts`it might be possible to automatically map this to the correct form required by the `endpointHealthComponent` as demonstrated below:
 
 ```ts
-const apis: Array<[name: string, config: EndpointComponentOptions]> =  ...
+const apis: Array<[name: string, config: EndpointHealthComponentOptions]> =  ...
 
 const middleware = monitoringMiddleware({
   applicationInfo,
-  healthComponents: apis.map(([name, config]) => endpointComponent(logger, name, config)),
+  healthComponents: apis.map(([name, config]) => endpointHealthComponent(logger, name, config)),
 })
 ```
 

--- a/packages/monitoring/bin/migrate.sh
+++ b/packages/monitoring/bin/migrate.sh
@@ -27,7 +27,7 @@ printStage "* Replace healthcheck middleware"
 cat > server/middleware/setUpHealthChecks.ts <<EOL
 import express, { Router } from 'express'
 
-import { monitoringMiddleware, endpointComponent } from '@ministryofjustice/hmpps-monitoring'
+import { monitoringMiddleware, endpointHealthComponent } from '@ministryofjustice/hmpps-monitoring'
 import type { ApplicationInfo } from '../applicationInfo'
 import logger from '../../logger'
 import config from '../config'
@@ -39,7 +39,7 @@ export default function setUpHealthChecks(applicationInfo: ApplicationInfo): Rou
 
   const middleware = monitoringMiddleware({
     applicationInfo,
-    healthComponents: apiConfig.map(([name, options]) => endpointComponent(logger, name, options)),
+    healthComponents: apiConfig.map(([name, options]) => endpointHealthComponent(logger, name, options)),
   })
 
   router.get('/health', middleware.health)

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-monitoring",
-  "version": "0.0.1-alpha.5",
+  "version": "0.0.1-alpha.6",
   "description": "Retrieve and display health and status information from external services and internal components",
   "author": "hmpps-developers",
   "license": "MIT",

--- a/packages/monitoring/src/main/HealthCheck.test.ts
+++ b/packages/monitoring/src/main/HealthCheck.test.ts
@@ -28,16 +28,14 @@ describe('HealthCheck', () => {
       const result = await healthChecker.check()
       const expectedResult = {
         status: 'UP',
-        components: [
-          {
-            name: healthCheckComponents[0].options.name,
+        components: {
+          [healthCheckComponents[0].options.name]: {
             status: 'UP',
           },
-          {
-            name: healthCheckComponents[1].options.name,
+          [healthCheckComponents[1].options.name]: {
             status: 'UP',
           },
-        ],
+        },
       }
 
       expect(result).toEqual(expectedResult)
@@ -50,18 +48,15 @@ describe('HealthCheck', () => {
       const result = await healthChecker.check()
       const expectedResult = {
         status: 'DOWN',
-        components: [
-          {
-            name: healthCheckComponents[0].options.name,
+        components: {
+          [healthCheckComponents[0].options.name]: {
             status: 'UP',
           },
-          {
-            name: healthCheckComponents[1].options.name,
+          [healthCheckComponents[1].options.name]: {
             status: 'DOWN',
           },
-        ],
+        },
       }
-
       expect(result).toEqual(expectedResult)
     })
   })

--- a/packages/monitoring/src/main/HealthCheck.ts
+++ b/packages/monitoring/src/main/HealthCheck.ts
@@ -6,14 +6,15 @@ export default class HealthCheck {
 
   /** Run and return component health checks */
   async check(): Promise<HealthCheckResult> {
-    const components = this.healthComponents.filter(component => component.isEnabled())
+    const enabledComponents = this.healthComponents.filter(component => component.isEnabled())
 
-    if (components.length) {
-      const componentHealthResults = await Promise.all(components.map(component => component.health()))
+    if (enabledComponents.length) {
+      const componentHealthResults = await Promise.all(enabledComponents.map(component => component.health()))
+      const formattedResults = Object.fromEntries(componentHealthResults.map(({ name, ...rest }) => [name, rest]))
 
       return {
         status: componentHealthResults.some(component => component.status === 'DOWN') ? 'DOWN' : 'UP',
-        components: componentHealthResults,
+        components: formattedResults,
       }
     }
 

--- a/packages/monitoring/src/main/MonitoringMiddleware.test.ts
+++ b/packages/monitoring/src/main/MonitoringMiddleware.test.ts
@@ -63,12 +63,11 @@ describe('HealthCheckMiddleware', () => {
       expect(mockRes.status).toHaveBeenCalledWith(200)
       expect(mockRes.json).toHaveBeenCalledWith({
         status: 'UP',
-        components: [
-          {
-            name: mockComponent.options.name,
+        components: {
+          [mockComponent.options.name]: {
             status: 'UP',
           },
-        ],
+        },
         ...mockShortDeploymentInfo,
       })
     })
@@ -86,12 +85,11 @@ describe('HealthCheckMiddleware', () => {
       expect(mockRes.status).toHaveBeenCalledWith(500)
       expect(mockRes.json).toHaveBeenCalledWith({
         status: 'DOWN',
-        components: [
-          {
-            name: mockComponent.options.name,
+        components: {
+          [mockComponent.options.name]: {
             status: 'DOWN',
           },
-        ],
+        },
         ...mockShortDeploymentInfo,
       })
     })

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
@@ -1,11 +1,11 @@
 import { createTestNock } from '../../test/utils'
-import EndpointComponent from './EndpointComponent'
-import type { EndpointComponentOptions } from '../types/EndpointComponentOptions'
+import EndpointHealthComponent from './EndpointHealthComponent'
+import type { EndpointHealthComponentOptions } from '../types/EndpointHealthComponentOptions'
 
-describe('EndpointComponent', () => {
+describe('EndpointHealthComponent', () => {
   let nock: ReturnType<typeof createTestNock>
   const componentName = 'test-component'
-  let endpointComponentOptions: EndpointComponentOptions
+  let endpointHealthComponentOptions: EndpointHealthComponentOptions
 
   const messages = jest.fn()
   const logger = {
@@ -15,7 +15,7 @@ describe('EndpointComponent', () => {
 
   beforeEach(() => {
     nock = createTestNock({ method: 'get', baseUrl: 'https://test.local', path: '/some-path' })
-    endpointComponentOptions = {
+    endpointHealthComponentOptions = {
       enabled: true,
       retries: 2,
       timeout: 1000,
@@ -31,9 +31,9 @@ describe('EndpointComponent', () => {
 
   it('should return UP status if the external service responds successfully', async () => {
     nock.scope.reply(200)
-    const endpointComponent = new EndpointComponent(logger, componentName, endpointComponentOptions)
+    const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
 
-    const result = await endpointComponent.health()
+    const result = await endpointHealthComponent.health()
 
     const expectedResult = {
       name: componentName,
@@ -49,17 +49,17 @@ describe('EndpointComponent', () => {
       connectionAttempts += 1
     })
 
-    const endpointComponent = new EndpointComponent(logger, componentName, endpointComponentOptions)
-    const result = await endpointComponent.health()
+    const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
+    const result = await endpointHealthComponent.health()
 
-    const expectedConnectionAttempts = 1 + Number(endpointComponentOptions.retries)
+    const expectedConnectionAttempts = 1 + Number(endpointHealthComponentOptions.retries)
     const expectedResult = {
       name: componentName,
       status: 'DOWN',
       details: {
         message: 'Internal Server Error',
         status: 500,
-        attempts: Number(endpointComponentOptions.retries) + 1,
+        attempts: Number(endpointHealthComponentOptions.retries) + 1,
       },
     }
 
@@ -70,8 +70,8 @@ describe('EndpointComponent', () => {
   it('should log retries / failure if the external service', async () => {
     nock.scope.reply(500)
 
-    const endpointComponent = new EndpointComponent(logger, componentName, endpointComponentOptions)
-    await endpointComponent.health()
+    const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
+    await endpointHealthComponent.health()
 
     const logMessages = messages.mock.calls.map(call => call[0])
 
@@ -89,15 +89,15 @@ describe('EndpointComponent', () => {
       connectionAttempts += 1
     })
 
-    endpointComponentOptions.timeout = {
+    endpointHealthComponentOptions.timeout = {
       response: 100,
       deadline: 200,
     }
-    endpointComponentOptions.retries = 2
+    endpointHealthComponentOptions.retries = 2
 
-    const endpointComponent = new EndpointComponent(logger, componentName, endpointComponentOptions)
+    const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
 
-    const expectedConnectionAttempts = 1 + Number(endpointComponentOptions.retries)
+    const expectedConnectionAttempts = 1 + Number(endpointHealthComponentOptions.retries)
     const expectedResult = {
       name: componentName,
       status: 'DOWN',
@@ -109,7 +109,7 @@ describe('EndpointComponent', () => {
       },
     }
 
-    const result = await endpointComponent.health()
+    const result = await endpointHealthComponent.health()
 
     expect(result).toEqual(expectedResult)
     expect(connectionAttempts).toEqual(expectedConnectionAttempts)
@@ -121,11 +121,11 @@ describe('EndpointComponent', () => {
       connectionAttempts += 1
     })
 
-    endpointComponentOptions.retries = 0
+    endpointHealthComponentOptions.retries = 0
 
-    const endpointComponent = new EndpointComponent(logger, componentName, endpointComponentOptions)
+    const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
 
-    const expectedConnectionAttempts = 1 + Number(endpointComponentOptions.retries)
+    const expectedConnectionAttempts = 1 + Number(endpointHealthComponentOptions.retries)
     const expectedResult = {
       name: componentName,
       status: 'DOWN',
@@ -136,7 +136,7 @@ describe('EndpointComponent', () => {
       },
     }
 
-    const result = await endpointComponent.health()
+    const result = await endpointHealthComponent.health()
 
     expect(result).toEqual(expectedResult)
     expect(connectionAttempts).toEqual(expectedConnectionAttempts)

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.ts
@@ -4,14 +4,14 @@ import superagent from 'superagent'
 // eslint-disable-next-line import/no-extraneous-dependencies
 import Logger from 'bunyan'
 
-import { EndpointComponentOptions } from '../types/EndpointComponentOptions'
+import { EndpointHealthComponentOptions } from '../types/EndpointHealthComponentOptions'
 import { ComponentHealthResult, HealthComponent } from '../types/HealthComponent'
 
 /**
- * EndpointComponent class implements the HealthComponent interface.
+ * EndpointHealthComponent class implements the HealthComponent interface.
  * It checks the health status of an external service by sending HTTP requests to a specified endpoint.
  */
-export default class EndpointComponent implements HealthComponent {
+export default class EndpointHealthComponent implements HealthComponent {
   private readonly defaultOptions = {
     timeout: {
       response: 1500,
@@ -28,14 +28,14 @@ export default class EndpointComponent implements HealthComponent {
   constructor(
     private logger: Console | Logger,
     private readonly name: string,
-    private readonly options: EndpointComponentOptions,
+    private readonly options: EndpointHealthComponentOptions,
   ) {
     this.agent = options.url.startsWith('https')
       ? new HttpsAgent(options.agentConfig as HttpsOptions)
       : new Agent(options.agentConfig as HttpOptions)
 
     this.healthUrl = `${options.url}${options.healthPath}`
-    this.options = { ...this.defaultOptions, ...options } as EndpointComponentOptions
+    this.options = { ...this.defaultOptions, ...options } as EndpointHealthComponentOptions
 
     logger.info(`Monitoring health of external service '${name}' on: '${this.healthUrl}'`)
   }

--- a/packages/monitoring/src/main/index.ts
+++ b/packages/monitoring/src/main/index.ts
@@ -1,5 +1,5 @@
 import MonitoringMiddleware from './MonitoringMiddleware'
-import EndpointComponent from './components/EndpointComponent'
+import EndpointHealthComponent from './components/EndpointHealthComponent'
 
 /**
  * monitoringMiddleware provides middleware functions for handling
@@ -19,12 +19,12 @@ export function monitoringMiddleware(...args: ConstructorParameters<typeof Monit
 }
 
 /**
- * EndpointComponent class implements the HealthComponent interface.
+ * EndpointHealthComponent class implements the HealthComponent interface.
  * It checks the health status of an external service by sending HTTP requests to a specified endpoint.
  */
-export function endpointComponent(...args: ConstructorParameters<typeof EndpointComponent>) {
-  return new EndpointComponent(...args)
+export function endpointHealthComponent(...args: ConstructorParameters<typeof EndpointHealthComponent>) {
+  return new EndpointHealthComponent(...args)
 }
 
 export type { HealthComponent, ComponentHealthResult } from './types/HealthComponent'
-export type { EndpointComponentOptions } from './types/EndpointComponentOptions'
+export type { EndpointHealthComponentOptions } from './types/EndpointHealthComponentOptions'

--- a/packages/monitoring/src/main/types/EndpointHealthComponentOptions.ts
+++ b/packages/monitoring/src/main/types/EndpointHealthComponentOptions.ts
@@ -1,6 +1,6 @@
 import type { HttpOptions, HttpsOptions } from 'agentkeepalive'
 
-export interface EndpointComponentOptions {
+export interface EndpointHealthComponentOptions {
   /** The root URL of the external service to be health-checked. */
   url: string
   /** The path that represents the endpoint that will be called on the external service to be health-checked. The full endpoint url that will be called is `${url}${healthPath}`. */

--- a/packages/monitoring/src/main/types/MonitoringOptions.ts
+++ b/packages/monitoring/src/main/types/MonitoringOptions.ts
@@ -7,8 +7,8 @@ import type { ComponentHealthResult, HealthComponent } from './HealthComponent'
 export interface HealthCheckResult {
   /** The overall health status of the application. */
   status: string
-  /** (Optional) An array of health check results for individual components. */
-  components?: ComponentHealthResult[]
+  /** (Optional) A mapping of component name to component health result. */
+  components?: Record<string, Omit<ComponentHealthResult, 'name'>>
 }
 
 /**


### PR DESCRIPTION
* Renaming and changing references from `EndpointComponent` -> `EndpointHealthComponent`
* Fix API response so it's consistent with existing apps / spring boot actuator responses
* Bump version for next alpha release

Previous library response structure:
```ts
{
  status: 'UP',
  components: [
    {
      name: 'comp-1',
      status: 'DOWN',
      details: {
        message: 'Internal Server Error',
        status: 500,
        attempts: 3
      },
    },
    {
      name: 'comp-2',
      status: 'UP',
    },
  ],
}
```

"standard" response structure:

```ts
{
  status: 'UP',
  components: {
    'comp-1': {
      status: 'DOWN',
      details: {
        message: 'Internal Server Error',
        status: 500,
        attempts: 3,
      },
    },
    'comp-2': {
      status: 'UP',
    },
  },
}
```

