### PR TITLE
Moving to detect which packages need publishing automatically

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -83,34 +83,39 @@ jobs:
         run: |
           npm run clean
           npm run build
-      - name: Publish changed packages
+      - name: Publish new versions of packages
         run: |
           root_path=$(pwd)
 
-          echo "→ Finding paths to packages whose package.json was changed in the last commit"
-          changed_package_json_paths=$(
-            git diff --name-only HEAD HEAD~ |
-            grep -E 'packages/[^/]+/package.json'
-          )
-          echo "${changed_package_json_paths}"
+          echo "→ Finding packages"
+          all_package_json_files=$( find packages -maxdepth 2 -name package.json )
+          echo "${all_package_json_files}"
 
-          echo "${changed_package_json_paths}" | while read -r changed_package_json_path
+          echo "${all_package_json_files}" | while read -r package_json_files
           do
-            changed_package_path=$(dirname "${changed_package_json_path}")
-            cd "${root_path}/${changed_package_path}"
-
+            package_dir=$(dirname "${package_json_files}")
+            
+            cd "${root_path}/${package_dir}"
             name=$(jq -r .name package.json)
+
+            latest_version=$(npm view $name version)
             version=$(jq -r .version package.json)
-            echo "→ Will publish version ${version} of ${name}…"
+            
+            if [ "$version" == "$latest_version" ]; then
+              echo "package ${name} has already published latest version: ${version}, skipping..."
 
-            echo "→ Building package ${name}"
-            package_name=$(npm pack)
+            else
+              echo "→ Existing published version is ${latest_version}, publishing version ${version} of ${name}…"
 
-            echo "→ Uploading package ${package_name} to Github release"
-            gh release upload ${{ github.event.release.tag_name }} "${package_name}"
+              echo "→ Building package ${name}"
+              package_name=$(npm pack)
 
-            echo "→ Publishing package ${name} v${version} to npmjs.com"
-            npm publish --provenance --access public
+              echo "→ Uploading package ${package_name} to Github release"
+              gh release upload ${{ github.event.release.tag_name }} "${package_name}"
+
+              echo "→ Publishing package ${name} v${version} to npmjs.com"
+              npm publish --provenance --access public
+            fi
           done
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,7 +10,7 @@ on:
       - main
   # when a release is published
   release:
-    types: [ published ]
+    types: [published]
   # and manually
   workflow_dispatch:
 
@@ -68,9 +68,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          # need this setting to be able to check changes in last commit
-          fetch-depth: 0
       - name: Setup node with public npmjs.com registry
         uses: actions/setup-node@v4
         with:
@@ -98,7 +95,7 @@ jobs:
             cd "${root_path}/${package_dir}"
             name=$(jq -r .name package.json)
 
-            latest_version=$(npm view $name version)
+            latest_version=$(npm view $name version || echo unpublished)
             version=$(jq -r .version package.json)
             
             if [ "$version" == "$latest_version" ]; then

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ When a new version needs to be released, these steps should be followed as part 
 3) Update version in package.json for the updated packages, _not_ the root project.
 4) Create pull request and review as usual.
 5) Create a tag on the `main` branch for the pull request’s squashed merge commit.
-   This is important! The publish process relies one the last commit to determine which packages have changed.
    The tag name can be in the form `[package]-[version]`, but automation does not rely on this.
 6) On Github, create a new release from this tag. This kicks off the Github actions pipeline to publish changed packages
    to npmjs.com and as tarball attachments to the release itself.


### PR DESCRIPTION
Previously relied on the last commit changing a package, and for that package to have had an updated version number sometime in the past - it's very easy to accidentally touch a package that you don't want to release and for it to be included and break the release of another package.

This does mean that any release after a package version change will release that package - so we'll need to make sure changing the version is the last thing we want to release it. 

[example output](https://github.com/ministryofjustice/hmpps-typescript-lib/actions/runs/11908687640/job/33184574527)