### PR TITLE
Release a new @ministryofjustice/eslint-config-hmpps with updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@tsconfig/node22": "^22.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
-    "rollup": "^4.25.0",
+    "rollup": "^4.27.3",
     "rollup-plugin-dts": "^6.1.1",
     "ts-jest": "^29.2.5",
     "typescript": "^5.6.3"

--- a/packages/eslint-config-hmpps/CHANGELOG.md
+++ b/packages/eslint-config-hmpps/CHANGELOG.md
@@ -1,9 +1,14 @@
 # History of changes
 
+## 0.0.1-alpha.9
+
+Pre-release for testing with HMPPS projects.
+Updated dependencies should once again allow typescript to use `no-unused-expressions` and other rules.
+
 ## 0.0.1-alpha.8
 
 Pre-release for testing with HMPPS projects.
-Fixed js doc annotation to help with auto-complete 
+Fixed js doc annotation to help with auto-complete
 
 ## 0.0.1-alpha.7
 

--- a/packages/eslint-config-hmpps/package.json
+++ b/packages/eslint-config-hmpps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/eslint-config-hmpps",
-  "version": "0.0.1-alpha.8",
+  "version": "0.0.1-alpha.9",
   "description": "ESLint rules for HMPPS typescript projects",
   "keywords": [
     "eslint",
@@ -30,12 +30,12 @@
     "lint-fix": "eslint . --cache --max-warnings 0 --fix"
   },
   "dependencies": {
-    "@eslint/eslintrc": "3.1.0",
-    "@eslint/js": "^9.14.0",
-    "@typescript-eslint/eslint-plugin": "^8.13.0",
-    "@typescript-eslint/parser": "^8.13.0",
+    "@eslint/eslintrc": "3.2.0",
+    "@eslint/js": "^9.15.0",
+    "@typescript-eslint/eslint-plugin": "^8.15.0",
+    "@typescript-eslint/parser": "^8.15.0",
     "confusing-browser-globals": "^1.0.11",
-    "eslint": "9.14.0",
+    "eslint": "^9.15.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.6.3",
     "eslint-plugin-cypress": "^4.0.0",


### PR DESCRIPTION
Dependency pin in #28 should no longer be needed now that [typescript-eslint/issues/10338](https://github.com/typescript-eslint/typescript-eslint/issues/10338) has been addressed.