### PR TITLE
Hack for packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@rollup/plugin-commonjs": "^28.0.2",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-typescript": "^12.1.2",
+    "rollup-plugin-copy": "^3.5.0",
     "@tsconfig/node22": "^22.0.0",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ministryofjustice/hmpps-rest-client",
+  "name": "hmpps-rest-client",
   "version": "0.0.1-alpha.1",
   "description": "Standardized, reusable REST client for use with HMPPS services",
   "author": "hmpps-developers",
@@ -21,7 +21,7 @@
     "node": "20 || 22"
   },
   "scripts": {
-    "build": "rollup -c rollup.config.ts --bundleConfigAsCjs",
+    "build": "rollup -c rollup.config.ts --bundleConfigAsCjs && rm -rf ./dist",
     "clean": "rm -rf ./dist/",
     "test": "tsc && jest",
     "lint": "eslint src --cache --max-warnings 0",

--- a/packages/rest-client/rollup.config.ts
+++ b/packages/rest-client/rollup.config.ts
@@ -8,6 +8,7 @@ import pkg from './package.json'
 /* eslint-enable import/no-extraneous-dependencies */
 
 const outputDir = path.resolve(__dirname, '../../dist', pkg.name)
+pkg.name = `@ministryofjustice/${pkg.name}`
 
 export default [
   {
@@ -28,20 +29,9 @@ export default [
           {
             src: 'package.json',
             dest: outputDir,
-            transform: () => {
-              return JSON.stringify(
-                {
-                  ...pkg,
-                  name: `@ministryofjustice/${pkg.name}`,
-                  devDependencies: {},
-                },
-                null,
-                2,
-              )
-            },
+            transform: () => JSON.stringify(pkg, null, 2),
           },
-          { src: '*.md', dest: outputDir },
-          { src: 'dist', dest: outputDir },
+          { src: ['dist', '*.md'], dest: outputDir },
         ],
       }),
     ],

--- a/packages/rest-client/rollup.config.ts
+++ b/packages/rest-client/rollup.config.ts
@@ -1,10 +1,13 @@
 /* eslint-disable import/no-extraneous-dependencies */
+import path from 'path'
 import typescript from '@rollup/plugin-typescript'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import { dts } from 'rollup-plugin-dts'
+import copy from 'rollup-plugin-copy'
+import pkg from './package.json'
 /* eslint-enable import/no-extraneous-dependencies */
 
-import pkg from './package.json'
+const outputDir = path.resolve(__dirname, '../../dist', pkg.name)
 
 export default [
   {
@@ -13,8 +16,35 @@ export default [
       { file: pkg.main, format: 'cjs', sourcemap: true },
       { file: pkg.module, format: 'esm', sourcemap: true },
     ],
-    plugins: [nodeResolve({ preferBuiltins: true }), typescript({ tsconfig: './tsconfig.json', noEmitOnError: true })],
     external: [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})],
+    plugins: [
+      nodeResolve({ preferBuiltins: true }),
+      typescript({
+        tsconfig: './tsconfig.json',
+        noEmitOnError: true,
+      }),
+      copy({
+        targets: [
+          {
+            src: 'package.json',
+            dest: outputDir,
+            transform: () => {
+              return JSON.stringify(
+                {
+                  ...pkg,
+                  name: `@ministryofjustice/${pkg.name}`,
+                  devDependencies: {},
+                },
+                null,
+                2,
+              )
+            },
+          },
+          { src: '*.md', dest: outputDir },
+          { src: 'dist', dest: outputDir },
+        ],
+      }),
+    ],
   },
   {
     input: 'dist/main/index.d.ts',


### PR DESCRIPTION
- Set the package name to just be the package name, no `@ministryofjustice` base
- Built package will be copied into `/dist/package-name` with just the `dist`, `package.json` and `*.MD` files
- Manipulate final package.json to re-add the `@ministryofjustice` base to the package name