### PR TITLE
Fix issues with verification client

### DIFF
--- a/packages/auth-clients/package.json
+++ b/packages/auth-clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-auth-clients",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "description": "Clients for authenticating and verifying tokens using the HMPPS Authentication estate",
   "author": "hmpps-developers",
   "license": "MIT",

--- a/packages/auth-clients/src/main/VerificationClient.test.ts
+++ b/packages/auth-clients/src/main/VerificationClient.test.ts
@@ -16,7 +16,7 @@ describe('VerificationClient', () => {
   }
 
   beforeEach(() => {
-    fakeApi = nock(config.url)
+    fakeApi = nock(config.url, { badheaders: ['Content-Type'] })
     tokenVerificationClient = new VerificationClient(config, console)
   })
 
@@ -46,7 +46,7 @@ describe('VerificationClient', () => {
       })
 
       it('Calls verify endpoint and parses active response', async () => {
-        fakeApi.post('/token/verify').reply(200, { active: true })
+        fakeApi.post('/token/verify', '').reply(200, { active: true })
 
         const data = await tokenVerificationClient.verifyToken({
           user: { token: 'some_token', username: 'john.doe' },
@@ -58,7 +58,7 @@ describe('VerificationClient', () => {
       })
 
       it('Calls verify endpoint and parses inactive response', async () => {
-        fakeApi.post('/token/verify').reply(200, { active: false })
+        fakeApi.post('/token/verify', '').reply(200, { active: false })
 
         const data = await tokenVerificationClient.verifyToken({
           user: { token: 'some_token' },

--- a/packages/auth-clients/src/main/VerificationClient.ts
+++ b/packages/auth-clients/src/main/VerificationClient.ts
@@ -54,7 +54,9 @@ export default class VerificationClient extends RestClient {
     this.logger.debug(`Token request for user "${user.username}"`)
 
     try {
-      const response = (await this.post({ path: `/token/verify` }, asUser(user.token))) as { active: boolean }
+      const response = (await this.post({ path: `/token/verify`, data: undefined }, asUser(user.token))) as {
+        active: boolean
+      }
       if (response && response.active) {
         request.verified = true
         return true

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-rest-client",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "description": "Standardized, reusable REST client for use with HMPPS services",
   "author": "hmpps-developers",
   "license": "MIT",

--- a/packages/rest-client/src/main/RestClient.ts
+++ b/packages/rest-client/src/main/RestClient.ts
@@ -119,7 +119,7 @@ export default abstract class RestClient {
    */
   private async requestWithBody<Response = unknown, ErrorData = unknown>(
     method: 'patch' | 'post' | 'put',
-    { path, query = {}, headers = {}, responseType = '', data = {}, raw = false, retry = false }: RequestWithBody,
+    { path, query = {}, headers = {}, responseType = '', data, raw = false, retry = false }: RequestWithBody,
     authOptions?: AuthOptions | string,
   ): Promise<Response> {
     this.logger.info(`${this.name} ${method.toUpperCase()}: ${path}`)
@@ -240,8 +240,7 @@ export default abstract class RestClient {
    * @param authOptions - (Optional) Either an AuthOptions object, a raw JWT string, or undefined for no auth.
    * @returns A Readable stream containing the response data.
    */
-  // eslint-disable-next-line default-param-last
-  async stream({ path, headers = {} }: StreamRequest = {}, authOptions?: AuthOptions | string): Promise<Readable> {
+  async stream({ path, headers = {} }: StreamRequest, authOptions?: AuthOptions | string): Promise<Readable> {
     this.logger.info(`${this.name} streaming: ${path}`)
 
     const token = await this.resolveToken(authOptions)

--- a/packages/rest-client/src/main/types/Request.ts
+++ b/packages/rest-client/src/main/types/Request.ts
@@ -9,7 +9,7 @@ export interface Request {
 }
 
 export interface RequestWithBody extends Request {
-  data?: Record<string, unknown> | string | Array<unknown>
+  data?: Record<string, unknown> | string | Array<unknown> | undefined
   retry?: boolean
 }
 

--- a/packages/rest-client/src/main/types/Request.ts
+++ b/packages/rest-client/src/main/types/Request.ts
@@ -9,7 +9,7 @@ export interface Request {
 }
 
 export interface RequestWithBody extends Request {
-  data?: Record<string, unknown> | string
+  data?: Record<string, unknown> | string | Array<unknown>
   retry?: boolean
 }
 


### PR DESCRIPTION
We were passing an empty object by default {} which had the side effect of setting the content type to application/json

Token verification would then read the json object as a string and then attempt to verify it as a token

Also fixing issue with not being able to post arrays and removing eslint warning - it doesn't make sense to default a path to undefined, we should force the caller to specify