### PR TITLE
Rest client improvements

### DIFF
--- a/packages/rest-client/README.md
+++ b/packages/rest-client/README.md
@@ -22,9 +22,10 @@ Usage is best demonstrated by the [HMPPS typescript template](https://github.com
 New projects based on this template will automatically adopt this package.
 
 ### RestClient
+
 The package provides an abstract RestClient class that you can extend to create API clients tailored to your service needs.
 
-```
+```ts
 import RestClient from '@ministryofjustice/hmpps-rest-client'
 import { ApiConfig } from './types/ApiConfig'
 import { AuthOptions } from './types/AuthOptions'
@@ -56,14 +57,38 @@ class ExampleApiClient extends RestClient {
 export default new ExampleApiClient()
 ```
 
+When using `hmpps-auth-clients` and dependency injection this might look like:
+
+```ts
+import { AuthenticationClient, RestClient } from '@ministryofjustice/hmpps-rest-client'
+import config from '../config'
+import logger from '../../logger'
+
+export default class ExampleApiClient extends RestClient {
+  constructor(authenticationClient: AuthenticationClient) {
+    super('exampleApiClient', config.apis.exampleApi, logger, authenticationClient)
+  }
+  ...
+}
+```
+
+```ts
+// data/index.ts
+const tokenStore = config.redis.enabled ? new RedisTokenStore(createRedisClient()) : new InMemoryTokenStore()
+const authClient = new AuthenticationClient(config.apis.hmppsAuth, logger, tokenStore)
+const client = new ExampleApiClient(authClient)
+```
+
 ### Authentication
+
 This library accepts an optional `AuthenticationClient` provider which implements
 a `getToken` endpoint, used for return system tokens.
 
 Additionally, the library provides
-* `asSystem` - for generating authentication options for making a request with a system token.
-* `asUser` - for generating authentication options for making a request with a user token.
-* You may also use the raw JWT string by passing it in place of authOptions.
+
+- `asSystem` - for generating authentication options for making a request with a system token.
+- `asUser` - for generating authentication options for making a request with a user token.
+- You may also use the raw JWT string by passing it in place of authOptions.
 
 ## Developing this package
 
@@ -73,5 +98,5 @@ This module uses rollup, to build:
 
 ## Testing changes to this library
 
-* `cd` to this directory and then link this library: `npm link`
-* Utilise the in-development library within a project by using: `npm link @ministryofjustice/hmpps-rest-client`
+- `cd` to this directory and then link this library: `npm link`
+- Utilise the in-development library within a project by using: `npm link @ministryofjustice/hmpps-rest-client`

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-rest-client",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "description": "Standardized, reusable REST client for use with HMPPS services",
   "author": "hmpps-developers",
   "license": "MIT",

--- a/packages/rest-client/src/main/helpers/sanitiseError.ts
+++ b/packages/rest-client/src/main/helpers/sanitiseError.ts
@@ -4,7 +4,7 @@ import { SanitisedError, UnsanitisedError } from '../types/Errors'
  * Converts an UnsanitisedError (superagent.ResponseError) into a simpler Error object,
  * omitting request information (e.g. sensitive request headers)
  */
-export default function sanitiseError<ErrorData = unknown>(error: UnsanitisedError): SanitisedError {
+export default function sanitiseError<ErrorData = unknown>(error: UnsanitisedError): SanitisedError<ErrorData> {
   const e = new Error() as SanitisedError<ErrorData>
 
   e.message = error.message

--- a/packages/rest-client/src/main/types/Request.ts
+++ b/packages/rest-client/src/main/types/Request.ts
@@ -1,11 +1,15 @@
-import { UnsanitisedError } from './Errors'
+import type superagent from 'superagent'
+import type http from 'http'
+import { SanitisedError, UnsanitisedError } from './Errors'
 
 export interface Request {
   path: string
   query?: object | string
   headers?: Record<string, string>
   responseType?: string
+  retries?: number
   raw?: boolean
+  errorHandler?: ErrorHandler
 }
 
 export interface RequestWithBody extends Request {
@@ -17,4 +21,18 @@ export interface StreamRequest {
   path?: string
   headers?: Record<string, string>
   errorLogger?: (e: UnsanitisedError) => void
+}
+
+export interface ErrorHandler {
+  <Response, ErrorData>(path: string, method: string, error: SanitisedError<ErrorData>): Response
+}
+
+export interface CallContext {
+  superagent: superagent.SuperAgent
+  token: string | undefined
+  agent: http.Agent
+}
+
+export interface Call<Response = unknown> {
+  (callContex: CallContext): Promise<Response>
 }


### PR DESCRIPTION
* allow overriding retries
* Adding ability to make bespoke calls without abandoning restclient entirely
* Added docs to demonstrate usage of client with hmpps-auth
* Support overriding error behaviour to cater for specialist handling of 404 responses
* Fix issue to provide type info after sanitising error
* Bumping in prep for new release