### PR TITLE
REST client tweaks

### DIFF
--- a/packages/rest-client/src/main/RestClient.test.ts
+++ b/packages/rest-client/src/main/RestClient.test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock'
 import express from 'express'
-import { PassThrough } from 'stream'
+import { PassThrough } from 'node:stream'
 import { NotFound } from 'http-errors'
 import RestClient from './RestClient'
 import { AgentConfig } from './types/ApiConfig'

--- a/packages/rest-client/src/main/RestClient.test.ts
+++ b/packages/rest-client/src/main/RestClient.test.ts
@@ -153,7 +153,7 @@ describe('RestClient', () => {
         systemAuthOptions,
       )
 
-      await expect(response).toStrictEqual(null)
+      expect(response).toStrictEqual(null)
 
       expect(nock.isDone()).toBe(true)
     })

--- a/packages/rest-client/src/main/RestClient.ts
+++ b/packages/rest-client/src/main/RestClient.ts
@@ -10,9 +10,9 @@ import { AuthenticationClient } from './types/AuthenticationClient'
 import { SanitisedError } from './types/Errors'
 
 /**
- * Abstract base class for REST API clients.
+ * Base class for REST API clients.
  */
-export default abstract class RestClient {
+export default class RestClient {
   private readonly agent: HttpAgent
 
   /**
@@ -23,7 +23,7 @@ export default abstract class RestClient {
    * @param logger - A logger instance for logging.
    * @param authenticationClient - (Optional) The client responsible for retrieving system authentication tokens.
    */
-  protected constructor(
+  constructor(
     protected readonly name: string,
     protected readonly config: ApiConfig,
     protected readonly logger: Logger | Console,

--- a/packages/rest-client/src/main/RestClient.ts
+++ b/packages/rest-client/src/main/RestClient.ts
@@ -1,6 +1,6 @@
 import { HttpAgent, HttpsAgent } from 'agentkeepalive'
 import superagent, { ResponseError } from 'superagent'
-import { Readable } from 'stream'
+import { Readable } from 'node:stream'
 import type Logger from 'bunyan'
 import sanitiseError from './helpers/sanitiseError'
 import { ApiConfig } from './types/ApiConfig'

--- a/packages/rest-client/src/main/helpers/sanitiseError.test.ts
+++ b/packages/rest-client/src/main/helpers/sanitiseError.test.ts
@@ -1,4 +1,4 @@
-import { SanitisedError, UnsanitisedError } from '../types/Errors'
+import { SanitisedError, type UnsanitisedError } from '../types/Errors'
 import sanitiseError from './sanitiseError'
 
 describe('sanitised error', () => {
@@ -19,14 +19,14 @@ describe('sanitised error', () => {
         },
         status: 404,
         statusText: 'Not found',
-        text: { details: 'details' },
+        text: 'details',
         body: { content: 'hello' },
       },
       message: 'Not Found',
       stack: 'stack description',
     } as unknown as UnsanitisedError
 
-    const e = new Error() as SanitisedError
+    const e = new SanitisedError()
     e.message = 'Not Found'
     e.text = 'details'
     e.responseStatus = 404
@@ -42,7 +42,7 @@ describe('sanitised error', () => {
       message: 'error description',
     } as unknown as UnsanitisedError
 
-    expect(sanitiseError(error)).toBeInstanceOf(Error)
+    expect(sanitiseError(error)).toBeInstanceOf(SanitisedError)
     expect(sanitiseError(error)).toHaveProperty('message', 'error description')
   })
 
@@ -51,7 +51,7 @@ describe('sanitised error', () => {
       property: 'unknown',
     } as unknown as UnsanitisedError
 
-    expect(sanitiseError(error)).toBeInstanceOf(Error)
+    expect(sanitiseError(error)).toBeInstanceOf(SanitisedError)
     expect(sanitiseError(error)).not.toHaveProperty('property')
   })
 })

--- a/packages/rest-client/src/main/helpers/sanitiseError.test.ts
+++ b/packages/rest-client/src/main/helpers/sanitiseError.test.ts
@@ -2,7 +2,7 @@ import { SanitisedError, type UnsanitisedError } from '../types/Errors'
 import sanitiseError from './sanitiseError'
 
 describe('sanitised error', () => {
-  it('it should omit the request headers from the error object ', () => {
+  it('should omit the request headers from the error object', () => {
     const error = {
       name: '',
       status: 404,
@@ -34,24 +34,30 @@ describe('sanitised error', () => {
     e.data = { content: 'hello' }
     e.stack = 'stack description'
 
-    expect(sanitiseError(error)).toEqual(e)
+    const sanitisedError = sanitiseError(error)
+
+    expect(sanitisedError).toEqual(e)
   })
 
-  it('it should return the error message', () => {
+  it('should return the error message', () => {
     const error = {
       message: 'error description',
     } as unknown as UnsanitisedError
 
-    expect(sanitiseError(error)).toBeInstanceOf(SanitisedError)
-    expect(sanitiseError(error)).toHaveProperty('message', 'error description')
+    const sanitisedError = sanitiseError(error)
+
+    expect(sanitisedError).toBeInstanceOf(SanitisedError)
+    expect(sanitisedError).toHaveProperty('message', 'error description')
   })
 
-  it('it should return an empty Error instance for an unknown error structure', () => {
+  it('should return an empty Error instance for an unknown error structure', () => {
     const error = {
       property: 'unknown',
     } as unknown as UnsanitisedError
 
-    expect(sanitiseError(error)).toBeInstanceOf(SanitisedError)
-    expect(sanitiseError(error)).not.toHaveProperty('property')
+    const sanitisedError = sanitiseError(error)
+
+    expect(sanitisedError).toBeInstanceOf(SanitisedError)
+    expect(sanitisedError).not.toHaveProperty('property')
   })
 })

--- a/packages/rest-client/src/main/helpers/sanitiseError.ts
+++ b/packages/rest-client/src/main/helpers/sanitiseError.ts
@@ -1,11 +1,11 @@
-import { SanitisedError, UnsanitisedError } from '../types/Errors'
+import { SanitisedError, type UnsanitisedError } from '../types/Errors'
 
 /**
  * Converts an UnsanitisedError (superagent.ResponseError) into a simpler Error object,
  * omitting request information (e.g. sensitive request headers)
  */
 export default function sanitiseError<ErrorData = unknown>(error: UnsanitisedError): SanitisedError<ErrorData> {
-  const e = new Error() as SanitisedError<ErrorData>
+  const e = new SanitisedError<ErrorData>()
 
   e.message = error.message
   e.stack = <string>error.stack

--- a/packages/rest-client/src/main/index.ts
+++ b/packages/rest-client/src/main/index.ts
@@ -7,5 +7,5 @@ export { AgentConfig } from './types/ApiConfig'
 
 export type { AuthOptions } from './types/AuthOptions'
 
-export type { SanitisedError } from './types/Errors'
+export { SanitisedError } from './types/Errors'
 export type { AuthenticationClient } from './types/AuthenticationClient'

--- a/packages/rest-client/src/main/types/Errors.ts
+++ b/packages/rest-client/src/main/types/Errors.ts
@@ -8,7 +8,7 @@ export class SanitisedError<ErrorData = unknown> extends Error {
 
   responseStatus?: number
 
-  headers?: unknown
+  headers?: Record<string, string>
 
   data?: ErrorData
 }

--- a/packages/rest-client/src/main/types/Request.ts
+++ b/packages/rest-client/src/main/types/Request.ts
@@ -1,5 +1,5 @@
 import type superagent from 'superagent'
-import type http from 'http'
+import type http from 'node:http'
 import { ErrorHandler, ErrorLogger } from './Errors'
 
 export interface Request<Response, ErrorData> {


### PR DESCRIPTION
- Allow REST client class to be used directly without subclassing. It doesn’t have any abstract properties.
  - And expose it’s private properties to subclasses for more flexibility.
- `SanitisedError` was defined as a class extending `Error` so we can instantiate it instead of type-asserting an `Error` instance