### PR TITLE
Revert prefixing node standard library imports with `node:`

### DIFF
--- a/packages/rest-client/CHANGELOG.md
+++ b/packages/rest-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.0.1-alpha.11
+
+Revert prefixing node standard library imports with “node:” because cypress is unhappy with them.
+
 ## 0.0.1-alpha.10
 
 Make `RestClient` non-abstract so that it can be instantiated directly in applications.

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-rest-client",
-  "version": "0.0.1-alpha.10",
+  "version": "0.0.1-alpha.11",
   "description": "Standardized, reusable REST client for use with HMPPS services",
   "author": "hmpps-developers",
   "license": "MIT",

--- a/packages/rest-client/src/main/RestClient.test.ts
+++ b/packages/rest-client/src/main/RestClient.test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock'
 import express from 'express'
-import { PassThrough } from 'node:stream'
+import { PassThrough } from 'stream'
 import { NotFound } from 'http-errors'
 import RestClient from './RestClient'
 import { AgentConfig } from './types/ApiConfig'

--- a/packages/rest-client/src/main/RestClient.ts
+++ b/packages/rest-client/src/main/RestClient.ts
@@ -1,6 +1,6 @@
 import { HttpAgent, HttpsAgent } from 'agentkeepalive'
 import superagent, { ResponseError } from 'superagent'
-import { Readable } from 'node:stream'
+import { Readable } from 'stream'
 import type Logger from 'bunyan'
 import sanitiseError from './helpers/sanitiseError'
 import { ApiConfig } from './types/ApiConfig'

--- a/packages/rest-client/src/main/types/Request.ts
+++ b/packages/rest-client/src/main/types/Request.ts
@@ -1,5 +1,5 @@
 import type superagent from 'superagent'
-import type http from 'node:http'
+import type http from 'http'
 import { ErrorHandler, ErrorLogger } from './Errors'
 
 export interface Request<Response, ErrorData> {


### PR DESCRIPTION
…because cypress is unhappy with them. Cypress uses webpack to construct the code that it runs inside the browser and it refuses to work with `import lib from 'node:lib'` style imports.

Undoes [#71 dd25e5b](https://github.com/ministryofjustice/hmpps-typescript-lib/pull/71/commits/dd25e5b2ec9c2c6d193c4c166bd05db49a02da9d)