### PR TITLE
Removing pipefail from prompt script

### DIFF
--- a/packages/precommit-hooks/CHANGELOG.md
+++ b/packages/precommit-hooks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.0.3
+
+Remove pipefail from prepare script
+
 ## 0.0.2
 
 Fix issue with alpine not having bash installed.

--- a/packages/precommit-hooks/bin/prepare.sh
+++ b/packages/precommit-hooks/bin/prepare.sh
@@ -3,7 +3,7 @@
 # This runs as part of any `npm install` via `prepare`
 # 
 
-set -eo pipefail
+set -e
 
 startStage() {
   printf "%s" "$1"

--- a/packages/precommit-hooks/package.json
+++ b/packages/precommit-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-precommit-hooks",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Precommit hooks for HMPPS typescript projects",
   "keywords": [
     "precommit"


### PR DESCRIPTION
This does not work when running in dash which happens in circle/github actions when running npm ci