### PR TITLE
RestClient - Add default SuperAgent behaviour for retries

### DIFF
--- a/packages/rest-client/src/main/RestClient.ts
+++ b/packages/rest-client/src/main/RestClient.ts
@@ -1,5 +1,5 @@
 import { HttpAgent, HttpsAgent } from 'agentkeepalive'
-import superagent, { ResponseError } from 'superagent'
+import superagent, { Response, ResponseError } from 'superagent'
 import { Readable } from 'stream'
 import type Logger from 'bunyan'
 import sanitiseError from './helpers/sanitiseError'
@@ -7,7 +7,7 @@ import { ApiConfig } from './types/ApiConfig'
 import { AuthOptions, TokenType } from './types/AuthOptions'
 import { Call, Request, RequestWithBody, StreamRequest } from './types/Request'
 import { AuthenticationClient } from './types/AuthenticationClient'
-import { SanitisedError } from './types/Errors'
+import { RetryError, SanitisedError } from './types/Errors'
 
 /**
  * Base class for REST API clients.
@@ -74,6 +74,19 @@ export default class RestClient {
     this.logger.warn({ ...error }, `Error calling ${this.name}, path: '${path}', verb: '${method}'`)
   }
 
+  private readonly ERROR_CODES = new Set([
+    'ETIMEDOUT',
+    'ECONNRESET',
+    'EADDRINUSE',
+    'ECONNREFUSED',
+    'EPIPE',
+    'ENOTFOUND',
+    'ENETUNREACH',
+    'EAI_AGAIN',
+  ])
+
+  private readonly STATUS_CODES = new Set([408, 413, 429, 500, 502, 503, 504, 521, 522, 524])
+
   /**
    * Returns a retry handler function.
    *
@@ -81,14 +94,28 @@ export default class RestClient {
    * @returns A function that handles retries.
    */
   private handleRetry(retry: boolean = true) {
-    return (err: Error) => {
+    return (error: RetryError, res?: Response) => {
       if (!retry) {
         return false
       }
-      if (err) {
-        this.logger.info(`Retry handler found API error with ${err.name} - ${err.message}`)
+
+      if (res && this.STATUS_CODES.has(res.status)) {
+        this.logger.info(`Retry handler found API error with status code ${res.status}`)
+        return true
       }
-      return undefined
+
+      if (error) {
+        this.logger.info(`Retry handler found API error with ${error.name} - ${error.message}`)
+        if (
+          (error?.code && this.ERROR_CODES.has(error.code)) ||
+          (error.timeout && error?.code === 'ECONNABORTED') ||
+          error.crossDomain
+        ) {
+          return true
+        }
+      }
+
+      return false
     }
   }
 

--- a/packages/rest-client/src/main/types/Errors.ts
+++ b/packages/rest-client/src/main/types/Errors.ts
@@ -22,3 +22,8 @@ export interface ErrorHandler<Response, ErrorData> {
 export interface ErrorLogger<ErrorData> {
   (path: string, method: string, error: SanitisedError<ErrorData>): void
 }
+
+export interface RetryError extends ResponseError {
+  code?: string
+  crossDomain?: boolean
+}


### PR DESCRIPTION
- Restore (similar to) default behaviour for retries based on status code / error code