### PR TITLE
Initial import of allowlist tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "/packages/auth-clients",
     "/packages/eslint-config-hmpps",
     "/packages/monitoring",
-    "/packages/precommit-hooks"
+    "/packages/precommit-hooks",
+    "/packages/npm-script-allowlist"
   ],
   "engines": {
     "node": "20 || 22"

--- a/packages/npm-script-allowlist/CHANGELOG.md
+++ b/packages/npm-script-allowlist/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change log
+
+## 0.0.1-alpha.1
+
+Pre-releases which should not be used in projects.

--- a/packages/npm-script-allowlist/LICENSE.md
+++ b/packages/npm-script-allowlist/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Crown Copyright (Ministry of Justice)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/npm-script-allowlist/README.md
+++ b/packages/npm-script-allowlist/README.md
@@ -1,0 +1,22 @@
+# @ministryofjustice/hmpps-npm-allow-scripts
+
+This package aims to restrict npm scripts from running unless as part of a predefined allowlist
+
+## Status
+
+**This library is currently: Alpha.**
+Teams are welcome to trial this library. Please provide feedback via slack to the `#typescript` channel.
+
+## Migrating existing projects
+
+#### Automatically installing the library
+
+The package will self install and initialised by running via npx:
+`npx @ministryofjustice/hmpps-npm-allow-scripts`
+
+Note: The project needs to be initialised before use - solely adding the library will make no difference.
+Once the project has been initialised, other developers should be able to develop against it without further configuration.
+
+### How this works
+
+...

--- a/packages/npm-script-allowlist/bin/hmpps-allow-scripts
+++ b/packages/npm-script-allowlist/bin/hmpps-allow-scripts
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+import fs from 'fs'
+import npmRunScript from '@npmcli/run-script'
+
+const CONFIG_LOCATION = `${process.cwd()}/.allowed-scripts.mjs`
+const packageLockJson = JSON.parse(fs.readFileSync('package-lock.json', 'utf-8'))
+
+console.log(`Gathering configuration information from ${CONFIG_LOCATION}\n`)
+
+const configuredAllowlistModule = await import(CONFIG_LOCATION)
+const config = Object.assign({}, configuredAllowlistModule).default
+
+const configuredAllowlist = Object.entries(config.allowlist)
+const dependencyScriptsToRun = config.dependencyScriptsToRun || ['preinstall', 'install', 'postinstall']
+const localScriptsToRun = config.localScriptsToRun || ['preinstall', 'install', 'postinstall']
+
+const packagesWithScripts = Object.entries(packageLockJson.packages)
+  .map(([name, { version, hasInstallScript }]) => ({ name, version, hasInstallScript }))
+  .filter(pkg => pkg.hasInstallScript)
+  .map(pkg => ({ ...pkg, nameWithVersion: `${pkg.name}@${pkg.version}` }))
+  .map(pkg => {
+    const configuredPackage = configuredAllowlist.find(([name]) => pkg.nameWithVersion === name)
+    const isConfigured = Boolean(configuredPackage)
+    return { ...pkg, configured: isConfigured, status: isConfigured ? configuredPackage[1] : '<MISSING>' }
+  })
+
+const configToPrint = Object.fromEntries(packagesWithScripts.map(pkg => [pkg.nameWithVersion, pkg.status]))
+
+console.log(`Current configuration: ${JSON.stringify(configToPrint, null, 2)}\n`)
+
+const missingPackages = packagesWithScripts.filter(pkg => !pkg.configured).map(pkg => pkg.nameWithVersion)
+if (missingPackages.length) {
+  console.log(`ERROR: Explicitly ALLOW/FORBID the following in ${CONFIG_LOCATION}:\n  ${missingPackages.join('\n  ')}`)
+  process.exit(1)
+}
+
+const allowed = packagesWithScripts.filter(pkg => pkg.status === 'ALLOW').map(pkg => pkg.name)
+if (!allowed.length) {
+  console.log(`No scripts to run`)
+  process.exit(0)
+}
+
+console.log('Running dependency scripts')
+for (const path of allowed) {
+  console.log(`- Running scripts for: ${pkg}`)
+  for (const event of dependencyScriptsToRun) {
+    await runScript({ path, event })  
+  }
+}
+
+console.log('Running local scripts')
+for (const event of localScriptsToRun) {
+    await runScript({ path, event })  
+}
+
+console.log('FIN!')
+
+async function runScript({ path, event }) {
+  await npmRunScript({ event, path, stdio: 'inherit' })
+}

--- a/packages/npm-script-allowlist/bin/init.sh
+++ b/packages/npm-script-allowlist/bin/init.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# Executed via npx to add and configure the library 
+# 
+
+set -euo pipefail
+
+startStage() {
+  printf "%s" "$1"
+}
+
+endStage() {
+  printf "%s\n" "$1"
+}
+
+printError() {
+  printf "\x1b[1;31m%s\x1b[0m\n" "$1"
+}
+
+endStage "Setting up hmpps npm script locker" 
+
+startStage "  * Adding/overwriting .npmrc script"
+printf "%s\n" \
+     "# This provides sensible defaults, this can be customised if necessary and changes will not be overwritten" \
+     "" \
+     "# Prevent preinstall, install, postinstall scripts from running by default" \
+     "ignore-scripts = true" \
+     "" \
+     "# Use exact versions in package.json when using npm install <pkg>" \
+     "save-exact = true" \
+     "" \
+     "# Fail if trying to use incorrect version of npm" \
+     "engine-strict = true" \
+     "" \
+     "# Show any output of scripts in the console " \
+     "foreground-scripts = true" \
+       > .npmrc
+endStage "  ✅"
+
+startStage "  * Adding default configuration file: .allowed-scripts.mjs"
+printf "%s\n" \
+     "import configureAllowedScripts from '@ministryofjustice/hmpps-npm-script-allowlist'" \
+     "" \
+     "export default configureAllowedScripts({" \
+     "   allowlist: {" \
+     "   }," \
+     "})" \
+     > .allowed-scripts.mjs
+endStage "  ✅"
+
+startStage "  * Adding set up script"
+npm pkg set --silent scripts.setup="npm ci && hmpps-npm-script-run-allowlist" 
+endStage "  ✅"
+
+startStage "  * Installing shared library"
+npm install --silent --save-dev @ministryofjustice/hmpps-npm-script-allowlist
+endStage "  ✅"
+
+startStage "  * Running allow scripts"
+npm run setup
+endStage "  ✅"
+
+# Could also add...
+# * add preinstall script which always fails if scripts are called as part of the npm lifecycle 
+#     - pkg set --silent  scripts.preinstall:"echo \"Run npm run setup to install run allowed lifecycle scripts\" && exit 1", 
+
+endStage "FIN!"

--- a/packages/npm-script-allowlist/eslint.config.mjs
+++ b/packages/npm-script-allowlist/eslint.config.mjs
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import hmppsConfig from '@ministryofjustice/eslint-config-hmpps'
+
+export default hmppsConfig()

--- a/packages/npm-script-allowlist/index.mjs
+++ b/packages/npm-script-allowlist/index.mjs
@@ -1,0 +1,26 @@
+/**
+ * @readonly
+ * @enum {'ALLOW' | 'FORBID'}
+ */
+export const Status = {
+  ALLOW: 'ALLOW',
+  FORBID: 'FORBID',
+}
+
+/**
+ * Types
+ * @typedef {Object} Config
+ * @property {Array<string>} localScriptsToRun - A list of the lifecycle scripts to run for this package
+ * @property {Array<string>} dependencyScriptsToRun - A list of the lifecycle scripts to run for each allowed dependency
+ * @property {Record<string, Status>} allowlist
+ */
+
+/**
+ * Provides information as to whether a script should be enabled or not.
+ *
+ * @param {Config} config
+ * @return {Config} an array of eslint config objects
+ */
+export default function configureAllowedScripts(config) {
+  return config
+}

--- a/packages/npm-script-allowlist/package.json
+++ b/packages/npm-script-allowlist/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@ministryofjustice/hmpps-npm-script-allowlist",
+  "version": "0.0.1-alpha.1",
+  "description": "A tool to restrict npm scripts from running unless as part of an allowlist",
+  "keywords": [
+    "npm",
+    "scripts"
+  ],
+  "author": "hmpps-developers",
+  "license": "MIT",
+  "homepage": "https://github.com/ministryofjustice/hmpps-typescript-lib/tree/main/packages/npm-scripts-allowlist#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ministryofjustice/hmpps-typescript-lib.git"
+  },
+  "main": "index.mjs",
+  "bin": {
+    "@ministryofjustice/hmpps-npm-script-allowlist": "./bin/init.sh",
+    "hmpps-npm-script-run-allowlist": "./bin/hmpps-allow-scripts"
+  },
+  "scripts": {
+    "lint": "eslint . --cache --max-warnings 0",
+    "lint-fix": "eslint . --cache --max-warnings 0 --fix",
+    "check-for-updates": "npx npm-check-updates -u"
+  },
+  "files": [
+    "*.md",
+    "bin/*",
+    "index.mjs"
+  ],
+  "engines": {
+    "node": "20 || 22"
+  },
+  "dependencies": {
+    "@npmcli/run-script": "10.0.0"
+  }
+}


### PR DESCRIPTION
The next step from [this](https://github.com/ministryofjustice/create-and-vary-a-licence/pull/1420)

## How it works:

A developer would configure a frontend service by running `npx @ministryofjustice/hmpps-npm-script-allowlist`

This:
* Sets some sensible defaults in .npmrc to prevent execution of scripts 
* Install the package 
* Adds a default configuration file
* Adds a new script called `setup`
* Runs the tool, which will likely fail allowing the developer to complete configuration

Developers would then: 
`npm install` to install packages but doesn't not execute any scripts
`npm run setup` runs `npm ci` (without scripts) and then executes scripts in this package to execute only those allowlisted scripts 

## Configuration

Configuring the tool consist of altering `./allowed-scripts.mjs` and setting `ALLOW `or `FORBID` entries in the `allowed-scripts.mjs`:
```
import configureAllowedScripts from '@ministryofjustice/hmpps-npm-script-allowlist/index.mjs'

export default configureAllowedScripts({
   allowlist: {
      "node_modules/@parcel/watcher@2.5.1": "ALLOW",
      "node_modules/cypress@14.5.4": "FORBID",
      "node_modules/dtrace-provider@0.8.8": "ALLOW",
      "node_modules/fsevents@2.3.3": "FORBID",
      "node_modules/unrs-resolver@1.11.1": "ALLOW"
   },
})
```

(The tool will play back the configuration and highlight versions which need to be added.) 

## Doesn't lavamoat do the same thing?

This is heavily inspired by [lavamoat's allowscripts](https://github.com/LavaMoat/LavaMoat/tree/main/packages/allow-scripts).

This works slightly differently: 
* Scripts need to be explicitly configured either to be included or not or the script will fail
* This uses the explicit version in the package-lock.json to key whether a script should run or not, rather than just the name of the package

## Use cases
There's a few different use cases this needs to support: 

* A developer checks out a project and wants to set it up ✅   
  - `npm run setup`
* A developer wants to patch ✅  
  - `(npm update` or `npm audit fix` - or  check-updates or whatevs ) && `npm run setup`
* A developer wants to install a new package ✅ 
  - `npm install X` && `npm run setup`
* CI builds image ✅  
  - `npm run setup`
  -  GHA would need customising to support `npm run setup` 
* A bot (dependabot/ renovate) applies updates ⚠️ 
  - need to figure out how this will work
