### PR TITLE
Enforcing minimum release age

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         versions:
-          - ">=23"
+          - ">=25"
     schedule:
       interval: weekly
       day: wednesday

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -52,9 +52,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 24
-      - name: Update npm
-        run: npm install -g npm@latest
+          node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm install
       - name: Clean build step
@@ -80,11 +78,9 @@ jobs:
       - name: Setup node with public npmjs.com registry
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 24
+          node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           scope: '@ministryofjustice'
-      - name: Update npm
-        run: npm install -g npm@latest
       - name: Install dependencies
         run: npm install
       - name: Build all packages

--- a/.npmrc
+++ b/.npmrc
@@ -11,3 +11,9 @@ engine-strict = true
 
 # Show any output of scripts in the console 
 foreground-scripts = true
+
+# Wait a minimum of 7 days before allowing a package to be released, this is to allow time for any issues to be discovered and fixed before the package is released
+min-release-age = 7
+
+# Don't allow git dependencies see here
+allow-git = none


### PR DESCRIPTION
Also allowing to float on latest appropriate version of npm for node release

The lint check was left to allow for minimum release ages to work for older node version builds