### PR TITLE
Pin to `monitor-opentelemetry-exporter` to more 'stable' beta version in azure-telemetry

### DIFF
--- a/packages/azure-telemetry/package.json
+++ b/packages/azure-telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-azure-telemetry",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "description": "Azure Application Insights telemetry using OpenTelemetry",
   "author": "hmpps-developers",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "check-for-updates": "npx npm-check-updates -u"
   },
   "peerDependencies": {
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.38",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.32",
     "@opentelemetry/api": "1.x",
     "@opentelemetry/api-logs": ">=0.200.0",
     "@opentelemetry/instrumentation": ">=0.200.0",


### PR DESCRIPTION
- Microsoft removed the `.38` beta for some reason, but they have `.32` as the long-standing published build
- Bump to package to `alpha.3`