### PR TITLE
Add cool-down period to dependabot’s updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       - dependency-name: "@types/node"
         versions:
           - ">=25"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "@ministryofjustice/*"
     schedule:
       interval: weekly
       day: wednesday
@@ -17,6 +21,10 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    cooldown:
+      default-days: 7
+      exclude:
+        - "ministryofjustice/*"
     schedule:
       interval: weekly
       day: wednesday


### PR DESCRIPTION
should prevent `npm error notarget No matching version found for globals@17.5.0 with a date before 4/9/2026, 12:11:22 PM.` type errors