### PR TITLE
Verify allowlist environment prior to running

### DIFF
--- a/packages/npm-script-allowlist/CHANGELOG.md
+++ b/packages/npm-script-allowlist/CHANGELOG.md
@@ -1,10 +1,22 @@
 # Change log
 
+## 0.0.5
+
+- **Environment verification feature**: New `environmentVerifier` function validates project configuration for secure npm script execution
+  - Ensures `.npmrc` file exists with `ignore-scripts=true` configuration
+  - Validates Dockerfile properly references `.npmrc` for container environments
+  - Prevents inadvertent circumvention of the security model
+  - Can be disabled via `NPM_SCRIPT_ALLOWLIST_VERIFICATION_DISABLED` environment variable
+
+### Reference
+
+For a complete example of proper project configuration, see [hmpps-template-typescript PR #719](https://github.com/ministryofjustice/hmpps-template-typescript/pull/719).
+
 ## 0.0.1-alpha.5
 
 Move to node 24
 
- @npmcli/run-script  ^10.0.0 →  ^10.0.2
+@npmcli/run-script ^10.0.0 → ^10.0.2
 
 ## 0.0.1-alpha.1
 
@@ -27,12 +39,13 @@ Fixing issue where it errored when trying to retrieve info for nested packages
 Add support for allowing/forbidding all versions, or a range of versions, for a package.
 
 For example,
+
 ```js
 export default configureAllowedScripts({
   allowlist: {
-    'package-a': 'FORBID',       // forbid all versions of package-a
+    'package-a': 'FORBID', // forbid all versions of package-a
     'package-b@^1.0.0': 'ALLOW', // allow 1.x versions of package-b
-    'package-c@1.2.3': 'ALLOW',  // allow specific version of package-c (same as before)
-  }
+    'package-c@1.2.3': 'ALLOW', // allow specific version of package-c (same as before)
+  },
 })
 ```

--- a/packages/npm-script-allowlist/README.md
+++ b/packages/npm-script-allowlist/README.md
@@ -39,7 +39,7 @@ To work with the project after that:
 
 A manual step is required to move CI and docker over to use `npm run setup` instead of `npm ci`
 
-## Verfiying the environment
+## Verifying the environment
 
 The environment verification ensures:
 

--- a/packages/npm-script-allowlist/README.md
+++ b/packages/npm-script-allowlist/README.md
@@ -33,10 +33,34 @@ The tool can then be configured with a list of packages that should be allowed t
 Entries can target an exact version, a semver range, or the package path with no version to match all installed versions at that path.
 
 To work with the project after that:
+
 - `npm install` will install packages but no longer executes any scripts due to the defaults set in `.npmrc`
 - `npm run setup` runs `npm ci` (without scripts) and then executes only those scripts that have been explicitly allowed.
 
 A manual step is required to move CI and docker over to use `npm run setup` instead of `npm ci`
+
+## Verfiying the environment
+
+The environment verification ensures:
+
+1. **.npmrc configuration** - Verifies that your `.npmrc` file exists and contains `ignore-scripts=true` to prevent unauthorized scripts from executing during `npm install`
+2. **Dockerfile npm setup** - If a Dockerfile exists in your project, verification attempts to detect if it correctly copies the `.npmrc` file into the container.
+
+### Why this matters
+
+These checks ensure that the security settings required by the allowlist system are consistently applied across development and deployment environments.
+
+This project assumes that preinstall and postinstall scripts have been disabled. Docker containers will bypass security restrictions if the `.npmrc` isn't copied over and there's been cases where the npmrc file hasn't been configured correctly.
+
+See the [hmpps-template-typescript PR #719](https://github.com/ministryofjustice/hmpps-template-typescript/pull/719) for a complete example of how to properly configure your project to pass these checks.
+
+### Disabling verification
+
+```bash
+NPM_SCRIPT_ALLOWLIST_VERIFICATION_DISABLED=true npm run setup
+```
+
+**Note:** Disabling verification should only be done in exceptional circumstances and is not recommended in production environments. If you encounter verification failures, it's better to fix the underlying configuration issues - please raise any issues on #typescript.
 
 ## Configuration
 
@@ -120,10 +144,10 @@ Copy the "Current Configuration" from above and use it to update: some-project/.
 
 This generally requires a bit of investigation!
 
-* There's a list of common vetted packages at specific versions in the hmpps-template-typescript project [here](https://github.com/ministryofjustice/hmpps-template-typescript/blob/main/.allowed-scripts.mjs).
-* One of the developers of lavamoat has curated a list of scripts which you likely can forbid [here](https://github.com/naugtur/can-i-ignore-scripts)
-* Otherwise you really need to determine what the specific flagged `preinstall`, `install`, `prepare` or `postinstall` scripts are doing.
-* If in doubt please ask the #typescript channel for help
+- There's a list of common vetted packages at specific versions in the hmpps-template-typescript project [here](https://github.com/ministryofjustice/hmpps-template-typescript/blob/main/.allowed-scripts.mjs).
+- One of the developers of lavamoat has curated a list of scripts which you likely can forbid [here](https://github.com/naugtur/can-i-ignore-scripts)
+- Otherwise you really need to determine what the specific flagged `preinstall`, `install`, `prepare` or `postinstall` scripts are doing.
+- If in doubt please ask the #typescript channel for help
 
 ### Testing
 

--- a/packages/npm-script-allowlist/bin/hmpps-allow-scripts
+++ b/packages/npm-script-allowlist/bin/hmpps-allow-scripts
@@ -4,4 +4,5 @@ const { run } = require('@ministryofjustice/hmpps-npm-script-allowlist/dist/inde
 
 run().catch(error => {
   console.error(`An error occurred: ${error}`)
+  throw error
 })

--- a/packages/npm-script-allowlist/package.json
+++ b/packages/npm-script-allowlist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-npm-script-allowlist",
-  "version": "0.0.4",
+  "version": "0.0.5-beta",
   "description": "A tool to restrict npm scripts from running unless as part of an allowlist",
   "keywords": [
     "npm",
@@ -15,7 +15,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",

--- a/packages/npm-script-allowlist/src/main/environment-verifier.test.ts
+++ b/packages/npm-script-allowlist/src/main/environment-verifier.test.ts
@@ -53,7 +53,7 @@ describe('environmentVerifier', () => {
       .mockReturnValueOnce('FROM node:18') // Dockerfile content without .npmrc reference
 
     expect(() => environmentVerifier()).toThrow(
-      'Please ensure your Dockerfile copies the .npmrc file to the container. See here for example: https://github.com/ministryofjustice/hmpps-template-typescript/pull/719',
+      /Please ensure your Dockerfile copies the \.npmrc file to the container\./,
     )
   })
 

--- a/packages/npm-script-allowlist/src/main/environment-verifier.test.ts
+++ b/packages/npm-script-allowlist/src/main/environment-verifier.test.ts
@@ -1,0 +1,140 @@
+import { existsSync, readFileSync } from 'fs'
+import { environmentVerifier } from './environment-verifier'
+
+jest.mock('fs')
+
+describe('environmentVerifier', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    delete process.env.NPM_SCRIPT_ALLOWLIST_VERIFICATION_DISABLED
+  })
+
+  it('should log and return early when NPM_SCRIPT_ALLOWLIST_VERIFICATION_DISABLED is true', () => {
+    process.env.NPM_SCRIPT_ALLOWLIST_VERIFICATION_DISABLED = 'true'
+    const mockLog = jest.fn()
+
+    environmentVerifier(mockLog)
+
+    expect(mockLog).toHaveBeenCalledWith('Environment verification is disabled.')
+  })
+
+  it('should throw error when .npmrc file does not exist', () => {
+    ;(existsSync as jest.Mock).mockReturnValueOnce(false)
+
+    expect(() => environmentVerifier()).toThrow(
+      '.npmrc file not found. Please ensure you have an .npmrc file in the root of your project with the correct ignore-scripts setting.',
+    )
+  })
+
+  it('should throw error when .npmrc does not have ignore-scripts=true', () => {
+    ;(existsSync as jest.Mock).mockReturnValueOnce(true)
+    ;(readFileSync as jest.Mock).mockReturnValueOnce('some-other-config=value')
+
+    expect(() => environmentVerifier()).toThrow(
+      'Incorrect .npmrc configuration. Please ensure your .npmrc file has "ignore-scripts=true" set.',
+    )
+  })
+
+  it('should not throw when .npmrc exists with correct configuration and no Dockerfile', () => {
+    ;(existsSync as jest.Mock)
+      .mockReturnValueOnce(true) // .npmrc exists
+      .mockReturnValueOnce(false) // Dockerfile does not exist
+    ;(readFileSync as jest.Mock).mockReturnValueOnce('ignore-scripts=true')
+
+    expect(() => environmentVerifier()).not.toThrow()
+  })
+
+  it('should throw error when Dockerfile exists but does not reference .npmrc', () => {
+    ;(existsSync as jest.Mock)
+      .mockReturnValueOnce(true) // .npmrc exists
+      .mockReturnValueOnce(true) // Dockerfile exists
+    ;(readFileSync as jest.Mock)
+      .mockReturnValueOnce('ignore-scripts=true') // .npmrc content
+      .mockReturnValueOnce('FROM node:18') // Dockerfile content without .npmrc reference
+
+    expect(() => environmentVerifier()).toThrow(
+      'Please ensure your Dockerfile copies the .npmrc file to the container. See here for example: https://github.com/ministryofjustice/hmpps-template-typescript/pull/719',
+    )
+  })
+
+  it('should not throw when both .npmrc and Dockerfile exist with correct configuration', () => {
+    ;(existsSync as jest.Mock)
+      .mockReturnValueOnce(true) // .npmrc exists
+      .mockReturnValueOnce(true) // Dockerfile exists
+    ;(readFileSync as jest.Mock)
+      .mockReturnValueOnce('ignore-scripts=true') // .npmrc content
+      .mockReturnValueOnce('COPY .npmrc /app/.npmrc') // Dockerfile content with .npmrc reference
+
+    expect(() => environmentVerifier()).not.toThrow()
+  })
+
+  it('should use custom log function when provided', () => {
+    const mockLog = jest.fn()
+    ;(existsSync as jest.Mock).mockReturnValueOnce(false)
+
+    expect(() => environmentVerifier(mockLog)).toThrow()
+
+    expect(mockLog).not.toHaveBeenCalled()
+  })
+
+  it('should call process.cwd() to construct file paths', () => {
+    jest.spyOn(process, 'cwd').mockReturnValue('/test/project')
+    ;(existsSync as jest.Mock)
+      .mockReturnValueOnce(true) // .npmrc exists
+      .mockReturnValueOnce(false) // Dockerfile does not exist
+    ;(readFileSync as jest.Mock).mockReturnValueOnce('ignore-scripts=true')
+
+    environmentVerifier()
+
+    expect(process.cwd).toHaveBeenCalled()
+    expect(existsSync).toHaveBeenCalledWith('/test/project/.npmrc')
+    expect(readFileSync).toHaveBeenCalledWith('/test/project/.npmrc', 'utf-8')
+
+    jest.restoreAllMocks()
+  })
+
+  it('should ignore whitespace around the equals sign', () => {
+    ;(existsSync as jest.Mock)
+      .mockReturnValueOnce(true) // .npmrc exists
+      .mockReturnValueOnce(false) // Dockerfile does not exist
+    ;(readFileSync as jest.Mock).mockReturnValueOnce('ignore-scripts = true')
+
+    expect(() => environmentVerifier()).not.toThrow()
+  })
+
+  it('should ignore multiple spaces around the equals sign', () => {
+    ;(existsSync as jest.Mock)
+      .mockReturnValueOnce(true) // .npmrc exists
+      .mockReturnValueOnce(false) // Dockerfile does not exist
+    ;(readFileSync as jest.Mock).mockReturnValueOnce('ignore-scripts  =  true')
+
+    expect(() => environmentVerifier()).not.toThrow()
+  })
+
+  it('should find ignore-scripts=true among multiple configuration lines', () => {
+    ;(existsSync as jest.Mock)
+      .mockReturnValueOnce(true) // .npmrc exists
+      .mockReturnValueOnce(false) // Dockerfile does not exist
+    ;(readFileSync as jest.Mock).mockReturnValueOnce('legacy-peer-deps=true\nignore-scripts=true\nautosave-tag=latest')
+
+    expect(() => environmentVerifier()).not.toThrow()
+  })
+
+  it('should handle leading and trailing whitespace on the line', () => {
+    ;(existsSync as jest.Mock)
+      .mockReturnValueOnce(true) // .npmrc exists
+      .mockReturnValueOnce(false) // Dockerfile does not exist
+    ;(readFileSync as jest.Mock).mockReturnValueOnce('  ignore-scripts=true  ')
+
+    expect(() => environmentVerifier()).not.toThrow()
+  })
+
+  it('should reject ignore-scripts with value other than true', () => {
+    ;(existsSync as jest.Mock).mockReturnValueOnce(true)
+    ;(readFileSync as jest.Mock).mockReturnValueOnce('ignore-scripts=false')
+
+    expect(() => environmentVerifier()).toThrow(
+      'Incorrect .npmrc configuration. Please ensure your .npmrc file has "ignore-scripts=true" set.',
+    )
+  })
+})

--- a/packages/npm-script-allowlist/src/main/environment-verifier.ts
+++ b/packages/npm-script-allowlist/src/main/environment-verifier.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'fs'
 
 export const environmentVerifier = (log: (...args: unknown[]) => void = console.log) => {
-  // if processs.env.NPM_SCRIPT_ALLOWLIST_VERIFICATION_DISABLED is set, skip verification
+  // if process.env.NPM_SCRIPT_ALLOWLIST_VERIFICATION_DISABLED is set, skip verification
   if (process.env.NPM_SCRIPT_ALLOWLIST_VERIFICATION_DISABLED === 'true') {
     log('Environment verification is disabled.')
     return

--- a/packages/npm-script-allowlist/src/main/environment-verifier.ts
+++ b/packages/npm-script-allowlist/src/main/environment-verifier.ts
@@ -1,0 +1,33 @@
+import { existsSync, readFileSync } from 'fs'
+
+export const environmentVerifier = (log: (...args: unknown[]) => void = console.log) => {
+  // if processs.env.NPM_SCRIPT_ALLOWLIST_VERIFICATION_DISABLED is set, skip verification
+  if (process.env.NPM_SCRIPT_ALLOWLIST_VERIFICATION_DISABLED === 'true') {
+    log('Environment verification is disabled.')
+    return
+  }
+
+  // if npmrc file does not exist throw error
+  if (!existsSync(`${process.cwd()}/.npmrc`)) {
+    throw new Error(
+      '.npmrc file not found. Please ensure you have an .npmrc file in the root of your project with the correct ignore-scripts setting.',
+    )
+  }
+
+  const npmrcContent = readFileSync(`${process.cwd()}/.npmrc`, 'utf-8')
+  const hasIgnoreScriptsConfig = npmrcContent.split('\n').some(line => /^\s*ignore-scripts\s*=\s*true\s*$/.test(line))
+
+  if (!hasIgnoreScriptsConfig) {
+    throw new Error('Incorrect .npmrc configuration. Please ensure your .npmrc file has "ignore-scripts=true" set.')
+  }
+
+  // if dockerfile exists, check it references the .npmrc file
+  if (existsSync(`${process.cwd()}/Dockerfile`)) {
+    const dockerfileContent = readFileSync(`${process.cwd()}/Dockerfile`, 'utf-8')
+    if (!dockerfileContent.includes('.npmrc')) {
+      throw new Error(
+        'Please ensure your Dockerfile copies the .npmrc file to the container. See here for example: https://github.com/ministryofjustice/hmpps-template-typescript/pull/719. (check .dockerignore does not reference .npmrc as well)',
+      )
+    }
+  }
+}

--- a/packages/npm-script-allowlist/src/main/index.ts
+++ b/packages/npm-script-allowlist/src/main/index.ts
@@ -4,6 +4,7 @@ import npmRunScript from '@npmcli/run-script'
 import { readConfiguration } from './configuration-reader'
 import { fetchPackageInfo } from './fetch-package-info'
 import { Runner } from './runner'
+import { environmentVerifier } from './environment-verifier'
 
 export { configureAllowedScripts, type Config } from './project-configuration'
 
@@ -17,5 +18,6 @@ export async function run() {
     runScript: ({ path, event }) => npmRunScript({ event, path, stdio: 'inherit' }),
     fetchPackageInfo,
     readConfiguration,
+    verifyEnvironment: environmentVerifier,
   }).run()
 }

--- a/packages/npm-script-allowlist/src/main/runner.test.ts
+++ b/packages/npm-script-allowlist/src/main/runner.test.ts
@@ -12,6 +12,7 @@ describe('run()', () => {
   const mockRunScript = jest.fn()
   const mockFetchPackages = jest.fn()
   const mockReadConfiguration = jest.fn()
+  const mockVerifyEnvironment = jest.fn()
 
   const deps = {
     readFile: mockReadFile,
@@ -22,6 +23,7 @@ describe('run()', () => {
     runScript: mockRunScript,
     fetchPackageInfo: mockFetchPackages,
     readConfiguration: mockReadConfiguration,
+    verifyEnvironment: mockVerifyEnvironment,
   }
 
   const mockPackageLockJson = {
@@ -65,8 +67,34 @@ describe('run()', () => {
     mockReadConfiguration.mockReturnValue(mockDerivedConfig)
   })
 
+  it('should exit if env is not correct', async () => {
+    mockVerifyEnvironment.mockImplementation(() => {
+      throw new Error('exit')
+    })
+
+    await expect(new Runner(deps).run()).rejects.toThrow('exit')
+    expect(mockVerifyEnvironment).toHaveBeenCalled()
+  })
+
   it('should run scripts when configuration is correct', async () => {
     await expect(new Runner(deps).run()).resolves.not.toThrow()
+
+    expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('Running dependency scripts'))
+    expect(mockRunScript).toHaveBeenCalledWith({ path: 'package-a', event: 'install' })
+
+    expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('Running local scripts'))
+    expect(mockRunScript).toHaveBeenCalledWith({ path: '.', event: 'postinstall' })
+
+    expect(mockLog).toHaveBeenCalledWith('FIN!')
+  })
+
+  // we know certain scripts will fail (e.g. postinstall scripts that expect to be run in the context of the package), but we don't want that to cause the whole process to fail.
+  it('should not error when scripts fail to execute', async () => {
+    await expect(new Runner(deps).run()).resolves.not.toThrow()
+
+    mockRunScript.mockImplementation(() => {
+      throw new Error('exit')
+    })
 
     expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('Running dependency scripts'))
     expect(mockRunScript).toHaveBeenCalledWith({ path: 'package-a', event: 'install' })

--- a/packages/npm-script-allowlist/src/main/runner.test.ts
+++ b/packages/npm-script-allowlist/src/main/runner.test.ts
@@ -65,6 +65,7 @@ describe('run()', () => {
     mockReadFile.mockReturnValue(JSON.stringify(mockPackageLockJson))
     mockDynamicImport.mockResolvedValue({ default: mockConfig })
     mockReadConfiguration.mockReturnValue(mockDerivedConfig)
+    mockVerifyEnvironment.mockReturnValue(undefined)
   })
 
   it('should exit if env is not correct', async () => {

--- a/packages/npm-script-allowlist/src/main/runner.test.ts
+++ b/packages/npm-script-allowlist/src/main/runner.test.ts
@@ -90,11 +90,11 @@ describe('run()', () => {
 
   // we know certain scripts will fail (e.g. postinstall scripts that expect to be run in the context of the package), but we don't want that to cause the whole process to fail.
   it('should not error when scripts fail to execute', async () => {
-    await expect(new Runner(deps).run()).resolves.not.toThrow()
-
     mockRunScript.mockImplementation(() => {
       throw new Error('exit')
     })
+
+    await expect(new Runner(deps).run()).resolves.not.toThrow()
 
     expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('Running dependency scripts'))
     expect(mockRunScript).toHaveBeenCalledWith({ path: 'package-a', event: 'install' })
@@ -102,6 +102,7 @@ describe('run()', () => {
     expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('Running local scripts'))
     expect(mockRunScript).toHaveBeenCalledWith({ path: '.', event: 'postinstall' })
 
+    expect(mockError).toHaveBeenCalled()
     expect(mockLog).toHaveBeenCalledWith('FIN!')
   })
 

--- a/packages/npm-script-allowlist/src/main/runner.ts
+++ b/packages/npm-script-allowlist/src/main/runner.ts
@@ -11,13 +11,26 @@ export type Dependencies = {
   runScript: (opts: { path: string; event: string }) => Promise<void>
   fetchPackageInfo: PackageFetcher
   readConfiguration: ConfigurationReader
+  verifyEnvironment(): void
 }
 
 export class Runner {
   constructor(private readonly deps: Dependencies) {}
 
   async run(): Promise<void> {
-    const { readFile, dynamicImport, log, error, exit, runScript, fetchPackageInfo, readConfiguration } = this.deps
+    const {
+      readFile,
+      dynamicImport,
+      log,
+      error,
+      exit,
+      runScript,
+      fetchPackageInfo,
+      readConfiguration,
+      verifyEnvironment,
+    } = this.deps
+
+    verifyEnvironment()
 
     const packageLockJson = JSON.parse(readFile('package-lock.json'))
     const configModule = await dynamicImport(`${process.cwd()}/.allowed-scripts.mjs`)
@@ -66,14 +79,22 @@ export class Runner {
     for (const path of packages.toRun) {
       log(`- Running scripts for: ${path}`)
       for (const event of scripts.dependencyScriptsToRun) {
-        await runScript({ path, event })
+        try {
+          await runScript({ path, event })
+        } catch (err) {
+          error(`Error running dependency script: ${event} for ${path}`, err)
+        }
       }
     }
 
     log('Running local scripts')
     for (const event of scripts.localScriptsToRun) {
       log(`- Running local scripts: ${event}`)
-      await runScript({ path: '.', event })
+      try {
+        await runScript({ path: '.', event })
+      } catch (err) {
+        error(`Error running local script: ${event}`, err)
+      }
     }
 
     log('FIN!')


### PR DESCRIPTION
This should hardfail when npmrc isn't available, misconfigured, or if there's a docker file that doesn't copy across the npmrc file to the container