### PR TITLE
(PoC / Demo) Adopt Changesets for package releases

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,12 @@
+# Changesets
+
+This directory stores changeset files for package releases.
+
+When a change should affect one or more published packages, run:
+
+```shell
+npm run changeset
+```
+
+Commit the generated markdown file with the code change. The release workflow will use these files to create or update
+the `Version Packages` pull request on `main`.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,9 +8,6 @@ on:
   push:
     branches:
       - main
-  # when a release is published
-  release:
-    types: [published]
   # and manually
   workflow_dispatch:
 
@@ -63,18 +60,21 @@ jobs:
         run: npm run lint
 
   publish:
-    name: Publish packages
+    name: Version or publish packages
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
       id-token: write
     needs:
       - test
       - lint
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
       - name: Setup node with public npmjs.com registry
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -83,42 +83,15 @@ jobs:
           scope: '@ministryofjustice'
       - name: Install dependencies
         run: npm install
-      - name: Build all packages
-        run: |
-          npm run clean
-          npm run build
-      - name: Publish new versions of packages
-        run: |
-          root_path=$(pwd)
-
-          echo "→ Finding packages"
-          all_package_json_files=$( find packages -maxdepth 2 -name package.json )
-          echo "${all_package_json_files}"
-
-          echo "${all_package_json_files}" | while read -r package_json_files
-          do
-            package_dir=$(dirname "${package_json_files}")
-
-            cd "${root_path}/${package_dir}"
-            name=$(jq -r .name package.json)
-
-            version=$(jq -r .version package.json)
-
-            # Check whether this specific version is already published on npm
-            if npm view "${name}@${version}" version >/dev/null 2>&1; then
-              echo "package ${name} version ${version} is already published, skipping..."
-            else
-              echo "→ Publishing version ${version} of ${name}…"
-
-              echo "→ Building package ${name}"
-              package_name=$(npm pack)
-
-              echo "→ Uploading package ${package_name} to Github release"
-              gh release upload ${{ github.event.release.tag_name }} "${package_name}"
-
-              echo "→ Publishing package ${name} v${version} to npmjs.com"
-              npm publish
-            fi
-          done
+      - name: Create release pull request or publish packages
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: npm run version-packages
+          publish: npm run release
+          title: Version Packages
+          commit: Version Packages
+          createGithubReleases: true
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -44,28 +44,24 @@ TODO: document adding a new sub-package
 
 ### Publishing process
 
-There is a Github actions pipeline to publish new releases of sub-packages.
+This repository uses Changesets to manage package versions, changelogs and publish ordering for sub-packages.
 When a new version needs to be released, these steps should be followed as part of the usual pull request process…
 
 1. Make necessary changes to package(s).
-2. Ensure the README.md and CHANGELOG.md files are correct.
-3. Update version in package.json for the updated packages, _not_ the root project.
+2. Run `npm run changeset` and describe the package changes that should be released.
+3. Commit the generated `.changeset/*.md` file alongside the code changes.
 4. Create pull request, get it reviewed and merge into `main`.
-5. Create a tag on the `main` branch for the pull request’s squashed merge commit.
-   The tag name can be in the form `[package]-[version]`, but automation does not rely on this.
-   So run `git fetch --tags` to get all the existing tags, `git tag` to list the tags and, for example, run
+5. When changesets land on `main`, the publish workflow creates or updates a `Version Packages` pull request containing
+   the generated version bumps and changelog updates.
+6. Review and merge the `Version Packages` pull request.
+7. When that pull request lands on `main`, the publish workflow builds the packages, publishes new versions to npmjs.com
+   and creates GitHub releases for the published packages.
+
+Package versions and changelog entries should not normally be edited by hand. Changesets generates those updates in the
+`Version Packages` pull request.
+
+If you need to inspect the generated release changes locally, run:
 
 ```shell
-git tag clients-0.0.1-alpha.6
-git push origin tag clients-0.0.1-alpha.6
-```
-
-6. On [Github](https://github.com/ministryofjustice/hmpps-typescript-lib/releases), create a new release from this tag.
-   This kicks off the Github actions pipeline to publish changed packages to npmjs.com and as tarball attachments to the
-   release itself.
-
-TODO: ideally, we would use something like this automatically, however squashing commits leaves the tag dangling
-
-```shell
-npm version --workspace [package] [major | minor | prerelease --preid=pre]
+npm run version-packages
 ```

--- a/package.json
+++ b/package.json
@@ -33,15 +33,19 @@
   "scripts": {
     "build": "npm run build --workspaces --if-present",
     "clean": "find . -name '.eslintcache' -delete && npm run clean --workspaces --if-present",
+    "changeset": "changeset",
     "lint": "npm run lint --workspaces --if-present",
     "lint-fix": "npm run lint-fix --workspaces --if-present",
+    "release": "npm run clean && npm run build && changeset publish",
     "test": "npm run test --workspaces --if-present",
+    "version-packages": "changeset version",
     "check-for-updates": "npm run --workspaces check-for-updates",
     "prepare": "hmpps-precommit-hooks-prepare",
     "precommit:secrets": "gitleaks git --pre-commit --redact --staged --verbose --config .gitleaks/config.toml --gitleaks-ignore-path .gitleaks/.gitleaksignore",
     "precommit:verify": "npm run clean && npm run build && npm run lint && npm test"
   },
   "devDependencies": {
+    "@changesets/cli": "^2.31.0",
     "@rollup/plugin-commonjs": "^28.0.9",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-typescript": "^12.3.0",

--- a/packages/azure-telemetry/src/main/TelemetryInitialiser.ts
+++ b/packages/azure-telemetry/src/main/TelemetryInitialiser.ts
@@ -6,6 +6,7 @@ import { ExpressInstrumentation, ExpressLayerType } from '@opentelemetry/instrum
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http'
 import { resourceFromAttributes } from '@opentelemetry/resources'
 import { BatchLogRecordProcessor, ConsoleLogRecordExporter, LoggerProvider } from '@opentelemetry/sdk-logs'
+import type { LogRecordExporter, ReadableLogRecord } from '@opentelemetry/sdk-logs'
 import { BatchSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base'
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions'
@@ -64,6 +65,26 @@ export async function flushTelemetry(): Promise<void> {
   }
 }
 
+function createCompatibleAzureLogExporter(connectionString: string): LogRecordExporter {
+  const exporter = new AzureMonitorLogExporter({ connectionString })
+
+  return {
+    export(logRecords: ReadableLogRecord[], resultCallback) {
+      return exporter.export(logRecords, resultCallback)
+    },
+    shutdown() {
+      return exporter.shutdown()
+    },
+    forceFlush() {
+      if ('forceFlush' in exporter && typeof exporter.forceFlush === 'function') {
+        return exporter.forceFlush()
+      }
+
+      return Promise.resolve()
+    },
+  }
+}
+
 function initialiseWithAzureMonitor(
   config: TelemetryConfig,
   filters: SpanFilterFn[],
@@ -71,6 +92,7 @@ function initialiseWithAzureMonitor(
   instrumentations: Instrumentation[],
 ): void {
   console.info(`Telemetry: Initialising Azure Monitor for ${config.serviceName}`)
+  const connectionString = config.connectionString as string
 
   const resource = resourceFromAttributes({
     [ATTR_SERVICE_NAME]: config.serviceName,
@@ -78,7 +100,7 @@ function initialiseWithAzureMonitor(
   })
 
   const azureExporter = new AzureMonitorTraceExporter({
-    connectionString: config.connectionString,
+    connectionString,
   })
 
   const spanProcessors = [new FilteringSpanProcessor(new BatchSpanProcessor(azureExporter), filters, modifiers)]
@@ -97,9 +119,7 @@ function initialiseWithAzureMonitor(
 
   provider.register()
 
-  const logProcessors = [
-    new BatchLogRecordProcessor(new AzureMonitorLogExporter({ connectionString: config.connectionString })),
-  ]
+  const logProcessors = [new BatchLogRecordProcessor(createCompatibleAzureLogExporter(connectionString))]
 
   if (config.debug) {
     logProcessors.push(new BatchLogRecordProcessor(new ConsoleLogRecordExporter()))


### PR DESCRIPTION
## Summary
- adopt Changesets for package versioning and release management in the monorepo
- replace the manual release tag and publish loop with the Changesets GitHub Action
- add the initial .changeset config and contributor guidance
- update the repository README to document the new release flow
- include the isolated azure telemetry log exporter compatibility fix so the branch builds cleanly against current main

## Validation
- npm install
- npm run changeset -- --help
- npm run build
