### PR TITLE
Use rest-client for monitoring health checks

### DIFF
--- a/packages/monitoring/CHANGELOG.md
+++ b/packages/monitoring/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 1.0.2
+
+Reuse `@ministryofjustice/hmpps-rest-client` for endpoint health-check transport while preserving the existing health
+check behavior and result shape.
+
 ## 1.0.1
 
 Allow all 2xx response codes to be successful for endpoint health components

--- a/packages/monitoring/README.md
+++ b/packages/monitoring/README.md
@@ -71,6 +71,9 @@ Reflecting dependency health via the /health endpoint will ensure that pingdom a
 
 The library provides an implementation of `HealthComponent`, `EndpointHealthComponent`, which is used to track the health of APIs that this service relies on.
 
+`EndpointHealthComponent` reuses `@ministryofjustice/hmpps-rest-client` for outbound HTTP transport, so applications
+that already standardise on that client do not have to maintain a separate health-check HTTP stack.
+
 These require:
 
 - An instance of the logger that your application uses

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-monitoring",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Retrieve and display health and status information from external services and internal components",
   "author": "hmpps-developers",
   "license": "MIT",
@@ -25,7 +25,7 @@
     "src/**/*"
   ],
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24"
   },
   "scripts": {
     "build": "rollup -c rollup.config.ts --bundleConfigAsCjs",
@@ -35,15 +35,14 @@
     "lint-fix": "eslint . --cache --max-warnings 0 --fix",
     "check-for-updates": "npx npm-check-updates -u"
   },
-  "dependencies": {
-    "@ministryofjustice/hmpps-rest-client": "^1.2.0"
-  },
   "devDependencies": {
     "@types/bunyan": "^1.8.11",
     "@types/express": "^5.0.6",
+    "@types/superagent": "^8.1.9",
     "nock": "^14.0.10"
   },
   "peerDependencies": {
-    "agentkeepalive": "4.x"
+    "agentkeepalive": "4.x",
+    "superagent": "^10.x"
   }
 }

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -35,14 +35,15 @@
     "lint-fix": "eslint . --cache --max-warnings 0 --fix",
     "check-for-updates": "npx npm-check-updates -u"
   },
+  "dependencies": {
+    "@ministryofjustice/hmpps-rest-client": "^1.2.0"
+  },
   "devDependencies": {
     "@types/bunyan": "^1.8.11",
     "@types/express": "^5.0.6",
-    "@types/superagent": "^8.1.9",
     "nock": "^14.0.10"
   },
   "peerDependencies": {
-    "agentkeepalive": "4.x",
-    "superagent": "^10.x"
+    "agentkeepalive": "4.x"
   }
 }

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -25,7 +25,7 @@
     "src/**/*"
   ],
   "engines": {
-    "node": "22 || 24"
+    "node": "20 || 22 || 24"
   },
   "scripts": {
     "build": "rollup -c rollup.config.ts --bundleConfigAsCjs",
@@ -35,14 +35,15 @@
     "lint-fix": "eslint . --cache --max-warnings 0 --fix",
     "check-for-updates": "npx npm-check-updates -u"
   },
+  "dependencies": {
+    "@ministryofjustice/hmpps-rest-client": "^1.2.0"
+  },
   "devDependencies": {
     "@types/bunyan": "^1.8.11",
     "@types/express": "^5.0.6",
-    "@types/superagent": "^8.1.9",
     "nock": "^14.0.10"
   },
   "peerDependencies": {
-    "agentkeepalive": "4.x",
-    "superagent": "^10.x"
+    "agentkeepalive": "4.x"
   }
 }

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.ts
@@ -1,11 +1,37 @@
-import Agent, { HttpOptions, HttpsOptions, HttpsAgent } from 'agentkeepalive'
-import superagent from 'superagent'
+import { RestClient, type AgentConfig, type ApiConfig, type SanitisedError } from '@ministryofjustice/hmpps-rest-client'
+import type { Response as SuperAgentResponse } from 'superagent'
 // annoyingly, eslint doesn't automatically consider @types/bunyuan a dev depdendency, it's not even directly referenced here
 // eslint-disable-next-line import/no-extraneous-dependencies
 import Logger from 'bunyan'
 
 import { EndpointHealthComponentOptions } from '../types/EndpointHealthComponentOptions'
 import { ComponentHealthResult, HealthComponent } from '../types/HealthComponent'
+
+type RetryError = Error & {
+  code?: string
+  timeout?: number
+  crossDomain?: boolean
+}
+
+const RETRYABLE_ERROR_CODES = new Set([
+  'ETIMEDOUT',
+  'ECONNRESET',
+  'EADDRINUSE',
+  'ECONNREFUSED',
+  'EPIPE',
+  'ENOTFOUND',
+  'ENETUNREACH',
+  'EAI_AGAIN',
+])
+
+const RETRYABLE_STATUS_CODES = new Set([408, 413, 429, 500, 502, 503, 504, 521, 522, 524])
+
+type HealthCheckResult = SuperAgentResponse | ComponentHealthResult
+
+const restClientLogger = {
+  debug: () => undefined,
+  warn: () => undefined,
+} as Console
 
 /**
  * EndpointHealthComponent class implements the HealthComponent interface.
@@ -21,21 +47,18 @@ export default class EndpointHealthComponent implements HealthComponent {
     enabled: true,
   }
 
-  private readonly agent: Agent
-
   private readonly healthUrl: string
+
+  private readonly healthClient: RestClient
 
   constructor(
     private logger: Console | Logger,
     private readonly name: string,
     private readonly options: EndpointHealthComponentOptions,
   ) {
-    this.agent = options.url.startsWith('https')
-      ? new HttpsAgent(options.agentConfig as HttpsOptions)
-      : new Agent(options.agentConfig as HttpOptions)
-
     this.healthUrl = `${options.url}${options.healthPath}`
     this.options = { ...this.defaultOptions, ...options } as EndpointHealthComponentOptions
+    this.healthClient = new RestClient(`${name} health`, this.createApiConfig(this.options), restClientLogger)
 
     logger.info(`Monitoring health of external service '${name}' on: '${this.healthUrl}'`)
   }
@@ -56,60 +79,105 @@ export default class EndpointHealthComponent implements HealthComponent {
    * @returns A promise that resolves to a ComponentCheckResult, indicating the health status of the service.
    */
   health = async (): Promise<ComponentHealthResult> => {
-    const { timeout, retries } = this.options
+    const { retries } = this.options
     const { name } = this
 
     let attemptsCount = 1
 
-    try {
-      const response = await superagent
-        .get(this.healthUrl)
-        .agent(this.agent)
-        .timeout(timeout as number)
-        .retry(retries, (err, res) => {
+    const response = await this.healthClient.get<HealthCheckResult, never>(
+      {
+        path: this.options.healthPath,
+        raw: true,
+        retries,
+        retryHandler: () => (error, responseToRetry) => {
+          const retryError = error as RetryError | undefined
+          const retryStatus = typeof responseToRetry?.status === 'number' ? responseToRetry.status : undefined
+
           attemptsCount += 1
-          if (err) {
+
+          if (retryError) {
             this.logger.info(
-              `Attempting to get health of external service '${name}', got: ${err.code} - ${err.message}`,
+              `Attempting to get health of external service '${name}', got: ${retryError.name} - ${retryError.message}`,
             )
-          } else if (res?.clientError || res?.serverError) {
-            this.logger.info(
-              `Attempting to get health of external service '${name}', received response: ${res.statusCode}`,
+
+            return (
+              (retryError.code && RETRYABLE_ERROR_CODES.has(retryError.code)) ||
+              (retryError.timeout && retryError.code === 'ECONNABORTED') ||
+              Boolean(retryError.crossDomain)
             )
           }
-        })
 
+          if (retryStatus && RETRYABLE_STATUS_CODES.has(retryStatus)) {
+            this.logger.info(
+              `Attempting to get health of external service '${name}', received response: ${retryStatus}`,
+            )
+
+            return true
+          }
+
+          return false
+        },
+        errorHandler: (_path, _method, error) => this.toDownResult(error, attemptsCount),
+      },
+      undefined,
+    )
+
+    if (this.isDownResult(response)) {
       return {
-        name,
-        status: response.status >= 200 && response.status <= 299 ? 'UP' : 'DOWN',
+        ...response,
       }
-    } catch (error: unknown) {
-      this.logger.warn(`Failed getting health of external service '${name}'`, (error as superagent.ResponseError).stack)
+    }
 
-      const responseError = error as superagent.ResponseError
-      if (responseError?.response) {
-        return {
-          name,
-          status: 'DOWN',
-          details: {
-            status: responseError.status,
-            message: responseError.message || 'Error response from external service',
-            attempts: attemptsCount,
-          },
-        }
-      }
+    return {
+      name,
+      status: response.status >= 200 && response.status <= 299 ? 'UP' : 'DOWN',
+    }
+  }
 
-      const genericError = error as NodeJS.ErrnoException
+  private createApiConfig(options: EndpointHealthComponentOptions): ApiConfig {
+    const timeout =
+      typeof options.timeout === 'number'
+        ? { response: options.timeout, deadline: options.timeout }
+        : {
+            response: options.timeout?.response ?? this.defaultOptions.timeout.response,
+            deadline: options.timeout?.deadline ?? this.defaultOptions.timeout.deadline,
+          }
+
+    return {
+      url: options.url,
+      timeout,
+      agent: options.agentConfig as AgentConfig,
+    }
+  }
+
+  private isDownResult(result: HealthCheckResult): result is ComponentHealthResult {
+    return typeof result.status === 'string'
+  }
+
+  private toDownResult(error: SanitisedError, attemptsCount: number): ComponentHealthResult {
+    this.logger.warn(`Failed getting health of external service '${this.name}'`, error.stack)
+
+    if (error.responseStatus) {
       return {
-        name,
+        name: this.name,
         status: 'DOWN',
         details: {
-          code: genericError.code,
-          error: genericError.errno,
-          message: genericError.message || 'Unknown error',
+          status: error.responseStatus,
+          message: error.message || 'Error response from external service',
           attempts: attemptsCount,
         },
       }
+    }
+
+    return {
+      name: this.name,
+      status: 'DOWN',
+      details: {
+        code: error.code,
+        error: error.errno,
+        message: error.message || 'Unknown error',
+        attempts: attemptsCount,
+      },
     }
   }
 }

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-rest-client",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Standardized, reusable REST client for use with HMPPS services",
   "author": "hmpps-developers",
   "license": "MIT",

--- a/packages/rest-client/src/main/helpers/sanitiseError.ts
+++ b/packages/rest-client/src/main/helpers/sanitiseError.ts
@@ -6,9 +6,12 @@ import { SanitisedError, type UnsanitisedError } from '../types/Errors'
  */
 export default function sanitiseError<ErrorData = unknown>(error: UnsanitisedError): SanitisedError<ErrorData> {
   const e = new SanitisedError<ErrorData>()
+  const networkError = error as unknown as NodeJS.ErrnoException
 
   e.message = error.message
   e.stack = <string>error.stack
+  e.code = networkError.code
+  e.errno = networkError.errno
 
   if (error.response) {
     e.text = error.response.text

--- a/packages/rest-client/src/main/types/Errors.ts
+++ b/packages/rest-client/src/main/types/Errors.ts
@@ -8,6 +8,10 @@ export class SanitisedError<ErrorData = unknown> extends Error {
 
   responseStatus?: number
 
+  code?: string
+
+  errno?: string | number
+
   headers?: Record<string, string>
 
   data?: ErrorData


### PR DESCRIPTION
## Summary
- make `EndpointHealthComponent` use `@ministryofjustice/hmpps-rest-client` instead of maintaining its own HTTP client implementation
- preserve the existing health-check result shape, retry logging, and retry attempt counting
- extend `SanitisedError` with network error metadata so monitoring can keep its current timeout and connection failure details

## Validation
- npm install --package-lock-only
- npm run build --workspace packages/rest-client
- npm run build --workspace packages/monitoring
- npx jest --config packages/rest-client/jest.config.mjs src/main/RestClient.test.ts --runInBand
- npx jest --config packages/monitoring/jest.config.mjs src/main/components/EndpointHealthComponent.test.ts --runInBand
