### PR TITLE
Make the HMPPS Rest Client proxy-aware, and make monitoring utilize proxy-aware agents for health checks

### DIFF
--- a/packages/monitoring/CHANGELOG.md
+++ b/packages/monitoring/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 1.2.0
+
+Add proxy-aware health check transport options, including support for preferred `agent`, legacy `agentConfig`, and explicit `transport` overrides that pass through to `@ministryofjustice/hmpps-rest-client`.
+
+## 1.1.0
+
+Update package metadata to align with the published 1.1.0 release.
+
 ## 1.0.2
 
 Reuse `@ministryofjustice/hmpps-rest-client` for endpoint health-check transport while preserving the existing health

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-monitoring",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Retrieve and display health and status information from external services and internal components",
   "author": "hmpps-developers",
   "license": "MIT",
@@ -36,7 +36,7 @@
     "check-for-updates": "npx npm-check-updates -u"
   },
   "dependencies": {
-    "@ministryofjustice/hmpps-rest-client": "^1.2.0"
+    "@ministryofjustice/hmpps-rest-client": "^1.3.0"
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.11",

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
@@ -11,6 +11,14 @@ describe('EndpointHealthComponent', () => {
   const originalNodeOptions = process.env.NODE_OPTIONS
   const nodeSupportsEnvProxy = Number.parseInt(process.versions.node.split('.')[0], 10) >= 24
 
+  const restoreEnvVar = (name: 'NODE_USE_ENV_PROXY' | 'NODE_OPTIONS', value: string | undefined) => {
+    if (value === undefined) {
+      delete process.env[name]
+    } else {
+      process.env[name] = value
+    }
+  }
+
   const messages = jest.fn()
   const logger = {
     info: messages,
@@ -33,8 +41,8 @@ describe('EndpointHealthComponent', () => {
   })
 
   afterEach(() => {
-    process.env.NODE_USE_ENV_PROXY = originalNodeUseEnvProxy
-    process.env.NODE_OPTIONS = originalNodeOptions
+    restoreEnvVar('NODE_USE_ENV_PROXY', originalNodeUseEnvProxy)
+    restoreEnvVar('NODE_OPTIONS', originalNodeOptions)
     nock.done()
   })
 
@@ -95,12 +103,17 @@ describe('EndpointHealthComponent', () => {
     expect(getInternalAgent(endpointHealthComponent)).toBe(customAgent)
   })
 
-  it('accepts hmpps-rest-client style agent config under the agent field', () => {
-    endpointHealthComponentOptions.agent = { timeout: 4321 }
+  it('accepts agent options under the agent field', () => {
+    endpointHealthComponentOptions.agent = { timeout: 4321, maxSockets: 7 }
 
     const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
 
-    expect((getInternalAgent(endpointHealthComponent) as { options: { timeout?: number } }).options.timeout).toBe(4321)
+    expect(
+      (getInternalAgent(endpointHealthComponent) as { options: { timeout?: number; maxSockets?: number } }).options,
+    ).toMatchObject({
+      timeout: 4321,
+      maxSockets: 7,
+    })
   })
 
   it.each([[200], [201], [204]])(

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
@@ -73,9 +73,25 @@ describe('EndpointHealthComponent', () => {
     expect(createAgent).toHaveBeenCalledWith({
       url: nock.baseUrl,
       healthPath: nock.uniquePath,
-      agentConfig: undefined,
+      agentConfig: expect.objectContaining({ timeout: 8000 }),
     })
     expect(getInternalAgent(endpointHealthComponent)).toBe(customAgent)
+  })
+
+  it('preserves legacy agentConfig options when creating a custom transport agent', () => {
+    const customAgent = new http.Agent({ keepAlive: true, timeout: 7654 })
+    const createAgent = jest.fn().mockReturnValue(customAgent)
+
+    endpointHealthComponentOptions.agentConfig = { timeout: 4321, maxSockets: 7 }
+    endpointHealthComponentOptions.transport = { createAgent }
+
+    new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
+
+    expect(createAgent).toHaveBeenCalledWith({
+      url: nock.baseUrl,
+      healthPath: nock.uniquePath,
+      agentConfig: expect.objectContaining({ timeout: 4321, maxSockets: 7 }),
+    })
   })
 
   it('accepts hmpps-rest-client style agent config under the agent field', () => {

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
@@ -1,3 +1,4 @@
+import http from 'http'
 import { createTestNock } from '../../test/utils'
 import EndpointHealthComponent from './EndpointHealthComponent'
 import type { EndpointHealthComponentOptions } from '../types/EndpointHealthComponentOptions'
@@ -6,12 +7,18 @@ describe('EndpointHealthComponent', () => {
   let nock: ReturnType<typeof createTestNock>
   const componentName = 'test-component'
   let endpointHealthComponentOptions: EndpointHealthComponentOptions
+  const originalNodeUseEnvProxy = process.env.NODE_USE_ENV_PROXY
+  const originalNodeOptions = process.env.NODE_OPTIONS
+  const nodeSupportsEnvProxy = Number.parseInt(process.versions.node.split('.')[0], 10) >= 24
 
   const messages = jest.fn()
   const logger = {
     info: messages,
     warn: messages,
   } as unknown as jest.Mocked<Console>
+
+  const getInternalAgent = (component: EndpointHealthComponent) =>
+    (component as unknown as { healthClient: { agent?: unknown } }).healthClient.agent
 
   beforeEach(() => {
     nock = createTestNock({ method: 'get', baseUrl: 'https://test.local', path: '/some-path' })
@@ -26,7 +33,69 @@ describe('EndpointHealthComponent', () => {
   })
 
   afterEach(() => {
+    process.env.NODE_USE_ENV_PROXY = originalNodeUseEnvProxy
+    process.env.NODE_OPTIONS = originalNodeOptions
     nock.done()
+  })
+
+  it('only defers to Node env proxy mode when the runtime supports it', () => {
+    process.env.NODE_USE_ENV_PROXY = '1'
+
+    const endpointHealthComponent = new EndpointHealthComponent(
+      logger,
+      componentName,
+      endpointHealthComponentOptions,
+    )
+
+    if (nodeSupportsEnvProxy) {
+      expect(getInternalAgent(endpointHealthComponent)).toBeUndefined()
+    } else {
+      expect(getInternalAgent(endpointHealthComponent)).toBeDefined()
+    }
+  })
+
+  it('uses an explicitly supplied custom agent when Node env proxy mode is enabled', () => {
+    process.env.NODE_USE_ENV_PROXY = '1'
+
+    const customAgent = new http.Agent({ keepAlive: true, timeout: 6543 })
+    endpointHealthComponentOptions.transport = { agent: customAgent }
+
+    const endpointHealthComponent = new EndpointHealthComponent(
+      logger,
+      componentName,
+      endpointHealthComponentOptions,
+    )
+
+    expect(getInternalAgent(endpointHealthComponent)).toBe(customAgent)
+  })
+
+  it('uses a custom agent created by transport.createAgent when Node env proxy mode is enabled', () => {
+    process.env.NODE_USE_ENV_PROXY = '1'
+
+    const customAgent = new http.Agent({ keepAlive: true, timeout: 7654 })
+    const createAgent = jest.fn().mockReturnValue(customAgent)
+    endpointHealthComponentOptions.transport = { createAgent }
+
+    const endpointHealthComponent = new EndpointHealthComponent(
+      logger,
+      componentName,
+      endpointHealthComponentOptions,
+    )
+
+    expect(createAgent).toHaveBeenCalledWith({
+      url: nock.baseUrl,
+      healthPath: nock.uniquePath,
+      agentConfig: undefined,
+    })
+    expect(getInternalAgent(endpointHealthComponent)).toBe(customAgent)
+  })
+
+  it('accepts hmpps-rest-client style agent config under the agent field', () => {
+    endpointHealthComponentOptions.agent = { timeout: 4321 }
+
+    const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
+
+    expect((getInternalAgent(endpointHealthComponent) as { options: { timeout?: number } }).options.timeout).toBe(4321)
   })
 
   it.each([[200], [201], [204]])(

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
@@ -9,7 +9,8 @@ describe('EndpointHealthComponent', () => {
   let endpointHealthComponentOptions: EndpointHealthComponentOptions
   const originalNodeUseEnvProxy = process.env.NODE_USE_ENV_PROXY
   const originalNodeOptions = process.env.NODE_OPTIONS
-  const nodeSupportsEnvProxy = Number.parseInt(process.versions.node.split('.')[0], 10) >= 24
+  const getMajorNodeVersion = () => Number.parseInt(process.version.split('.')[0].replace('v', ''), 10)
+  const nodeSupportsEnvProxy = getMajorNodeVersion() >= 24
 
   const restoreEnvVar = (name: 'NODE_USE_ENV_PROXY' | 'NODE_OPTIONS', value: string | undefined) => {
     if (value === undefined) {

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
@@ -9,8 +9,8 @@ describe('EndpointHealthComponent', () => {
   let endpointHealthComponentOptions: EndpointHealthComponentOptions
   const originalNodeUseEnvProxy = process.env.NODE_USE_ENV_PROXY
   const originalNodeOptions = process.env.NODE_OPTIONS
-  const getMajorNodeVersion = () => Number.parseInt(process.version.split('.')[0].replace('v', ''), 10)
-  const nodeSupportsEnvProxy = getMajorNodeVersion() >= 24
+  const [, major = '0'] = process.version.match(/^v(\d+)\.(\d+)\.(\d+)/) ?? []
+  const nodeSupportsEnvProxy = Number(major) >= 24
 
   const restoreEnvVar = (name: 'NODE_USE_ENV_PROXY' | 'NODE_OPTIONS', value: string | undefined) => {
     if (value === undefined) {

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
@@ -41,11 +41,7 @@ describe('EndpointHealthComponent', () => {
   it('only defers to Node env proxy mode when the runtime supports it', () => {
     process.env.NODE_USE_ENV_PROXY = '1'
 
-    const endpointHealthComponent = new EndpointHealthComponent(
-      logger,
-      componentName,
-      endpointHealthComponentOptions,
-    )
+    const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
 
     if (nodeSupportsEnvProxy) {
       expect(getInternalAgent(endpointHealthComponent)).toBeUndefined()
@@ -60,11 +56,7 @@ describe('EndpointHealthComponent', () => {
     const customAgent = new http.Agent({ keepAlive: true, timeout: 6543 })
     endpointHealthComponentOptions.transport = { agent: customAgent }
 
-    const endpointHealthComponent = new EndpointHealthComponent(
-      logger,
-      componentName,
-      endpointHealthComponentOptions,
-    )
+    const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
 
     expect(getInternalAgent(endpointHealthComponent)).toBe(customAgent)
   })
@@ -76,11 +68,7 @@ describe('EndpointHealthComponent', () => {
     const createAgent = jest.fn().mockReturnValue(customAgent)
     endpointHealthComponentOptions.transport = { createAgent }
 
-    const endpointHealthComponent = new EndpointHealthComponent(
-      logger,
-      componentName,
-      endpointHealthComponentOptions,
-    )
+    const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
 
     expect(createAgent).toHaveBeenCalledWith({
       url: nock.baseUrl,

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
@@ -85,13 +85,14 @@ describe('EndpointHealthComponent', () => {
     endpointHealthComponentOptions.agentConfig = { timeout: 4321, maxSockets: 7 }
     endpointHealthComponentOptions.transport = { createAgent }
 
-    new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
+    const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
 
     expect(createAgent).toHaveBeenCalledWith({
       url: nock.baseUrl,
       healthPath: nock.uniquePath,
       agentConfig: expect.objectContaining({ timeout: 4321, maxSockets: 7 }),
     })
+    expect(getInternalAgent(endpointHealthComponent)).toBe(customAgent)
   })
 
   it('accepts hmpps-rest-client style agent config under the agent field', () => {

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.ts
@@ -144,7 +144,7 @@ export default class EndpointHealthComponent implements HealthComponent {
   private createApiConfig(options: EndpointHealthComponentOptions): ApiConfig {
     const transportOptions = options.transport
     const createAgent = transportOptions?.createAgent
-    const agentConfig: AgentOptions = options.agent ?? options.agentConfig ?? new AgentConfig()
+    const resolvedAgentConfig: AgentOptions = options.agent ?? options.agentConfig ?? new AgentConfig()
     const timeout =
       typeof options.timeout === 'number'
         ? { response: options.timeout, deadline: options.timeout }
@@ -157,11 +157,11 @@ export default class EndpointHealthComponent implements HealthComponent {
       ? {
           agent: transportOptions.agent,
           createAgent: createAgent
-            ? ({ url, agentConfig }) =>
+            ? ({ url, agentConfig: transportAgentConfig }) =>
                 createAgent({
                   url,
                   healthPath: options.healthPath,
-                  agentConfig,
+                  agentConfig: transportAgentConfig,
                 })
             : undefined,
         }
@@ -170,7 +170,7 @@ export default class EndpointHealthComponent implements HealthComponent {
     return {
       url: options.url,
       timeout,
-      agent: agentConfig,
+      agent: resolvedAgentConfig,
       transport,
     }
   }

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.ts
@@ -152,18 +152,19 @@ export default class EndpointHealthComponent implements HealthComponent {
             response: options.timeout?.response ?? this.defaultOptions.timeout.response,
             deadline: options.timeout?.deadline ?? this.defaultOptions.timeout.deadline,
           }
+    const transportCreateAgent = createAgent
+      ? ({ url, agentConfig }: { url: string; agentConfig: AgentOptions }) =>
+          createAgent({
+            url,
+            healthPath: options.healthPath,
+            agentConfig,
+          })
+      : undefined
 
     const transport: TransportConfig | undefined = transportOptions
       ? {
           agent: transportOptions.agent,
-          createAgent: createAgent
-            ? ({ url, agentConfig: transportAgentConfig }) =>
-                createAgent({
-                  url,
-                  healthPath: options.healthPath,
-                  agentConfig: transportAgentConfig,
-                })
-            : undefined,
+          createAgent: transportCreateAgent,
         }
       : undefined
 

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.ts
@@ -1,6 +1,7 @@
 import {
   RestClient,
-  type AgentConfig,
+  AgentConfig,
+  type AgentOptions,
   type ApiConfig,
   type SanitisedError,
   type TransportConfig,
@@ -143,6 +144,7 @@ export default class EndpointHealthComponent implements HealthComponent {
   private createApiConfig(options: EndpointHealthComponentOptions): ApiConfig {
     const transportOptions = options.transport
     const createAgent = transportOptions?.createAgent
+    const agentConfig: AgentOptions = options.agent ?? options.agentConfig ?? new AgentConfig()
     const timeout =
       typeof options.timeout === 'number'
         ? { response: options.timeout, deadline: options.timeout }
@@ -168,7 +170,7 @@ export default class EndpointHealthComponent implements HealthComponent {
     return {
       url: options.url,
       timeout,
-      agent: (options.agentConfig ?? options.agent) as AgentConfig,
+      agent: agentConfig,
       transport,
     }
   }

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.ts
@@ -1,4 +1,10 @@
-import { RestClient, type AgentConfig, type ApiConfig, type SanitisedError } from '@ministryofjustice/hmpps-rest-client'
+import {
+  RestClient,
+  type AgentConfig,
+  type ApiConfig,
+  type SanitisedError,
+  type TransportConfig,
+} from '@ministryofjustice/hmpps-rest-client'
 import type { Response as SuperAgentResponse } from 'superagent'
 // annoyingly, eslint doesn't automatically consider @types/bunyuan a dev depdendency, it's not even directly referenced here
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -135,6 +141,8 @@ export default class EndpointHealthComponent implements HealthComponent {
   }
 
   private createApiConfig(options: EndpointHealthComponentOptions): ApiConfig {
+    const transportOptions = options.transport
+    const createAgent = transportOptions?.createAgent
     const timeout =
       typeof options.timeout === 'number'
         ? { response: options.timeout, deadline: options.timeout }
@@ -143,10 +151,25 @@ export default class EndpointHealthComponent implements HealthComponent {
             deadline: options.timeout?.deadline ?? this.defaultOptions.timeout.deadline,
           }
 
+    const transport: TransportConfig | undefined = transportOptions
+      ? {
+          agent: transportOptions.agent,
+          createAgent: createAgent
+            ? ({ url, agentConfig }) =>
+                createAgent({
+                  url,
+                  healthPath: options.healthPath,
+                  agentConfig,
+                })
+            : undefined,
+        }
+      : undefined
+
     return {
       url: options.url,
       timeout,
-      agent: options.agentConfig as AgentConfig,
+      agent: (options.agentConfig ?? options.agent) as AgentConfig,
+      transport,
     }
   }
 

--- a/packages/monitoring/src/main/index.ts
+++ b/packages/monitoring/src/main/index.ts
@@ -28,3 +28,4 @@ export function endpointHealthComponent(...args: ConstructorParameters<typeof En
 
 export type { HealthComponent, ComponentHealthResult } from './types/HealthComponent'
 export type { EndpointHealthComponentOptions } from './types/EndpointHealthComponentOptions'
+export type { EndpointHealthTransportOptions } from './types/EndpointHealthComponentOptions'

--- a/packages/monitoring/src/main/types/EndpointHealthComponentOptions.ts
+++ b/packages/monitoring/src/main/types/EndpointHealthComponentOptions.ts
@@ -1,4 +1,4 @@
-import type { AgentConfig, TransportConfig } from '@ministryofjustice/hmpps-rest-client'
+import type { AgentConfig, AgentOptions, TransportConfig } from '@ministryofjustice/hmpps-rest-client'
 import type http from 'http'
 
 export interface EndpointHealthTransportOptions extends Omit<TransportConfig, 'createAgent'> {
@@ -15,7 +15,7 @@ export interface EndpointHealthTransportOptions extends Omit<TransportConfig, 'c
    * This overrides both the default keepalive agent and Node env proxy auto-detection. The caller is responsible for
    * ensuring the supplied agent is compatible with any required proxying.
    */
-  createAgent?: (options: { url: string; healthPath: string; agentConfig?: AgentConfig }) => http.Agent
+  createAgent?: (options: { url: string; healthPath: string; agentConfig?: AgentOptions }) => http.Agent
 }
 
 export interface EndpointHealthComponentOptions {
@@ -37,7 +37,7 @@ export interface EndpointHealthComponentOptions {
   /** (Optional) Agent configuration from hmpps-rest-client ApiConfig. */
   agent?: AgentConfig
   /** (Optional) Agent configuration options for HTTP/HTTPS requests to the service. */
-  agentConfig?: AgentConfig
+  agentConfig?: AgentOptions
   /** (Optional) Explicit transport override for health checks. */
   transport?: EndpointHealthTransportOptions
 }

--- a/packages/monitoring/src/main/types/EndpointHealthComponentOptions.ts
+++ b/packages/monitoring/src/main/types/EndpointHealthComponentOptions.ts
@@ -1,4 +1,22 @@
-import type { HttpOptions, HttpsOptions } from 'agentkeepalive'
+import type { AgentConfig, TransportConfig } from '@ministryofjustice/hmpps-rest-client'
+import type http from 'http'
+
+export interface EndpointHealthTransportOptions extends Omit<TransportConfig, 'createAgent'> {
+  /**
+   * Explicit agent instance to use for health checks.
+   *
+   * When provided, the monitoring package will always use this agent, even when Node env proxy mode is enabled.
+   * The caller is responsible for ensuring the supplied agent is compatible with any required proxying.
+   */
+  agent?: http.Agent
+  /**
+   * Factory for creating an explicit health-check agent.
+   *
+   * This overrides both the default keepalive agent and Node env proxy auto-detection. The caller is responsible for
+   * ensuring the supplied agent is compatible with any required proxying.
+   */
+  createAgent?: (options: { url: string; healthPath: string; agentConfig?: AgentConfig }) => http.Agent
+}
 
 export interface EndpointHealthComponentOptions {
   /** The root URL of the external service to be health-checked. */
@@ -14,8 +32,12 @@ export interface EndpointHealthComponentOptions {
         response?: number
         deadline?: number
       }
-  /** (Optional) The number of retry attempts for the health check. Defaults to 2 */
+  /** (Optional) The number of retry attempts for the component's health check. Defaults to 2 */
   retries?: number
+  /** (Optional) Agent configuration from hmpps-rest-client ApiConfig. */
+  agent?: AgentConfig
   /** (Optional) Agent configuration options for HTTP/HTTPS requests to the service. */
-  agentConfig?: HttpsOptions | HttpOptions
+  agentConfig?: AgentConfig
+  /** (Optional) Explicit transport override for health checks. */
+  transport?: EndpointHealthTransportOptions
 }

--- a/packages/monitoring/src/main/types/EndpointHealthComponentOptions.ts
+++ b/packages/monitoring/src/main/types/EndpointHealthComponentOptions.ts
@@ -34,10 +34,23 @@ export interface EndpointHealthComponentOptions {
       }
   /** (Optional) The number of retry attempts for the component's health check. Defaults to 2 */
   retries?: number
-  /** (Optional) Agent configuration options for HTTP/HTTPS requests to the service. */
+  /**
+   * (Optional) Preferred agent configuration options for HTTP/HTTPS requests to the service.
+   *
+   * When both `agent` and `agentConfig` are supplied, `agent` takes precedence.
+   */
   agent?: AgentOptions
-  /** (Optional) Agent configuration options for HTTP/HTTPS requests to the service. */
+  /**
+   * (Optional) Legacy alias for `agent`.
+   *
+   * This is retained for backwards compatibility. When both `agent` and `agentConfig` are supplied, `agent` takes
+   * precedence.
+   */
   agentConfig?: AgentOptions
-  /** (Optional) Explicit transport override for health checks. */
+  /**
+   * (Optional) Explicit transport override for health checks.
+   *
+   * `transport.agent` and `transport.createAgent` take precedence over both `agent` and `agentConfig`.
+   */
   transport?: EndpointHealthTransportOptions
 }

--- a/packages/monitoring/src/main/types/EndpointHealthComponentOptions.ts
+++ b/packages/monitoring/src/main/types/EndpointHealthComponentOptions.ts
@@ -1,4 +1,4 @@
-import type { AgentConfig, AgentOptions, TransportConfig } from '@ministryofjustice/hmpps-rest-client'
+import type { AgentOptions, TransportConfig } from '@ministryofjustice/hmpps-rest-client'
 import type http from 'http'
 
 export interface EndpointHealthTransportOptions extends Omit<TransportConfig, 'createAgent'> {
@@ -34,8 +34,8 @@ export interface EndpointHealthComponentOptions {
       }
   /** (Optional) The number of retry attempts for the component's health check. Defaults to 2 */
   retries?: number
-  /** (Optional) Agent configuration from hmpps-rest-client ApiConfig. */
-  agent?: AgentConfig
+  /** (Optional) Agent configuration options for HTTP/HTTPS requests to the service. */
+  agent?: AgentOptions
   /** (Optional) Agent configuration options for HTTP/HTTPS requests to the service. */
   agentConfig?: AgentOptions
   /** (Optional) Explicit transport override for health checks. */

--- a/packages/rest-client/CHANGELOG.md
+++ b/packages/rest-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+# 1.3.0
+- Add proxy-aware transport handling so the client defers to Node env-proxy mode on supported runtimes instead of always constructing a keepalive agent.
+- Add `transport.agent` and `transport.createAgent` overrides for callers that need to supply or construct their own agent.
+
 # 1.1.0
 - Add support for multipart form data requests [PR-143](https://github.com/ministryofjustice/hmpps-typescript-lib/pull/143)
 

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-rest-client",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Standardized, reusable REST client for use with HMPPS services",
   "author": "hmpps-developers",
   "license": "MIT",

--- a/packages/rest-client/src/main/RestClient.test.ts
+++ b/packages/rest-client/src/main/RestClient.test.ts
@@ -30,8 +30,8 @@ class TestRestClient extends RestClient {
 const restClient = new TestRestClient()
 const originalNodeUseEnvProxy = process.env.NODE_USE_ENV_PROXY
 const originalNodeOptions = process.env.NODE_OPTIONS
-const getMajorNodeVersion = () => Number.parseInt(process.version.split('.')[0].replace('v', ''), 10)
-const nodeSupportsEnvProxy = getMajorNodeVersion() >= 24
+const [, major = '0'] = process.version.match(/^v(\d+)\.(\d+)\.(\d+)/) ?? []
+const nodeSupportsEnvProxy = Number(major) >= 24
 
 const restoreEnvVar = (name: 'NODE_USE_ENV_PROXY' | 'NODE_OPTIONS', value: string | undefined) => {
   if (value === undefined) {

--- a/packages/rest-client/src/main/RestClient.test.ts
+++ b/packages/rest-client/src/main/RestClient.test.ts
@@ -32,6 +32,14 @@ const originalNodeUseEnvProxy = process.env.NODE_USE_ENV_PROXY
 const originalNodeOptions = process.env.NODE_OPTIONS
 const nodeSupportsEnvProxy = Number.parseInt(process.versions.node.split('.')[0], 10) >= 24
 
+const restoreEnvVar = (name: 'NODE_USE_ENV_PROXY' | 'NODE_OPTIONS', value: string | undefined) => {
+  if (value === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = value
+  }
+}
+
 const systemAuthOptions: AuthOptions = {
   tokenType: TokenType.SYSTEM_TOKEN,
   user: {
@@ -61,8 +69,8 @@ describe('RestClient', () => {
   const getInternalAgent = (client: RestClient) => (client as unknown as { agent?: unknown }).agent
 
   afterEach(() => {
-    process.env.NODE_USE_ENV_PROXY = originalNodeUseEnvProxy
-    process.env.NODE_OPTIONS = originalNodeOptions
+    restoreEnvVar('NODE_USE_ENV_PROXY', originalNodeUseEnvProxy)
+    restoreEnvVar('NODE_OPTIONS', originalNodeOptions)
   })
 
   it('only defers to Node env proxy mode when the runtime supports it', () => {

--- a/packages/rest-client/src/main/RestClient.test.ts
+++ b/packages/rest-client/src/main/RestClient.test.ts
@@ -21,14 +21,9 @@ const baseApiConfig: ApiConfig = {
 
 class TestRestClient extends RestClient {
   constructor(config: ApiConfig = baseApiConfig) {
-    super(
-      'api-name',
-      config,
-      console,
-      {
-        getToken: jest.fn().mockResolvedValue('some_system_jwt'),
-      },
-    )
+    super('api-name', config, console, {
+      getToken: jest.fn().mockResolvedValue('some_system_jwt'),
+    })
   }
 }
 

--- a/packages/rest-client/src/main/RestClient.test.ts
+++ b/packages/rest-client/src/main/RestClient.test.ts
@@ -1,26 +1,29 @@
 import nock from 'nock'
+import http from 'http'
 import express from 'express'
 import { Response } from 'superagent'
 import { PassThrough } from 'stream'
 import { NotFound } from 'http-errors'
 import RestClient from './RestClient'
-import { AgentConfig } from './types/ApiConfig'
+import { AgentConfig, type ApiConfig } from './types/ApiConfig'
 import { AuthOptions, TokenType } from './types/AuthOptions'
 import { SanitisedError } from './types/Errors'
 import { CallContext } from './types/Request'
 
+const baseApiConfig: ApiConfig = {
+  url: 'http://localhost:8080/api',
+  timeout: {
+    response: 200,
+    deadline: 200,
+  },
+  agent: new AgentConfig(200),
+}
+
 class TestRestClient extends RestClient {
-  constructor() {
+  constructor(config: ApiConfig = baseApiConfig) {
     super(
       'api-name',
-      {
-        url: 'http://localhost:8080/api',
-        timeout: {
-          response: 200,
-          deadline: 200,
-        },
-        agent: new AgentConfig(200),
-      },
+      config,
       console,
       {
         getToken: jest.fn().mockResolvedValue('some_system_jwt'),
@@ -30,6 +33,9 @@ class TestRestClient extends RestClient {
 }
 
 const restClient = new TestRestClient()
+const originalNodeUseEnvProxy = process.env.NODE_USE_ENV_PROXY
+const originalNodeOptions = process.env.NODE_OPTIONS
+const nodeSupportsEnvProxy = Number.parseInt(process.versions.node.split('.')[0], 10) >= 24
 
 const systemAuthOptions: AuthOptions = {
   tokenType: TokenType.SYSTEM_TOKEN,
@@ -57,6 +63,54 @@ async function readAll(stream: NodeJS.ReadableStream): Promise<string> {
 }
 
 describe('RestClient', () => {
+  const getInternalAgent = (client: RestClient) => (client as unknown as { agent?: unknown }).agent
+
+  afterEach(() => {
+    process.env.NODE_USE_ENV_PROXY = originalNodeUseEnvProxy
+    process.env.NODE_OPTIONS = originalNodeOptions
+  })
+
+  it('only defers to Node env proxy mode when the runtime supports it', () => {
+    process.env.NODE_USE_ENV_PROXY = '1'
+
+    const client = new TestRestClient()
+
+    if (nodeSupportsEnvProxy) {
+      expect(getInternalAgent(client)).toBeUndefined()
+    } else {
+      expect(getInternalAgent(client)).toBeDefined()
+    }
+  })
+
+  it('uses an explicitly supplied transport agent when Node env proxy mode is enabled', () => {
+    process.env.NODE_USE_ENV_PROXY = '1'
+
+    const customAgent = new http.Agent({ keepAlive: true, timeout: 6543 })
+    const client = new TestRestClient({
+      ...baseApiConfig,
+      transport: { agent: customAgent },
+    })
+
+    expect(getInternalAgent(client)).toBe(customAgent)
+  })
+
+  it('uses a transport.createAgent factory when Node env proxy mode is enabled', () => {
+    process.env.NODE_USE_ENV_PROXY = '1'
+
+    const customAgent = new http.Agent({ keepAlive: true, timeout: 7654 })
+    const createAgent = jest.fn().mockReturnValue(customAgent)
+    const client = new TestRestClient({
+      ...baseApiConfig,
+      transport: { createAgent },
+    })
+
+    expect(createAgent).toHaveBeenCalledWith({
+      url: baseApiConfig.url,
+      agentConfig: baseApiConfig.agent,
+    })
+    expect(getInternalAgent(client)).toBe(customAgent)
+  })
+
   describe.each(['get', 'patch', 'post', 'put', 'delete'] as const)('%s', method => {
     afterEach(() => {
       nock.cleanAll()
@@ -619,10 +673,15 @@ describe('RestClient', () => {
       const receivedData = await restClient.makeRestClientCall<string>(
         systemAuthOptions,
         async ({ superagent, token, agent }: CallContext): Promise<string> => {
-          const result = await superagent
+          const request = superagent
             .get(`http://localhost:8080/api/some-path`)
             .auth(token as string, { type: 'bearer' })
-            .agent(agent)
+
+          if (agent) {
+            request.agent(agent)
+          }
+
+          const result = await request
 
           return result.body.message
         },

--- a/packages/rest-client/src/main/RestClient.test.ts
+++ b/packages/rest-client/src/main/RestClient.test.ts
@@ -30,7 +30,8 @@ class TestRestClient extends RestClient {
 const restClient = new TestRestClient()
 const originalNodeUseEnvProxy = process.env.NODE_USE_ENV_PROXY
 const originalNodeOptions = process.env.NODE_OPTIONS
-const nodeSupportsEnvProxy = Number.parseInt(process.versions.node.split('.')[0], 10) >= 24
+const getMajorNodeVersion = () => Number.parseInt(process.version.split('.')[0].replace('v', ''), 10)
+const nodeSupportsEnvProxy = getMajorNodeVersion() >= 24
 
 const restoreEnvVar = (name: 'NODE_USE_ENV_PROXY' | 'NODE_OPTIONS', value: string | undefined) => {
   if (value === undefined) {

--- a/packages/rest-client/src/main/RestClient.ts
+++ b/packages/rest-client/src/main/RestClient.ts
@@ -1,3 +1,4 @@
+import type http from 'http'
 import { HttpAgent, HttpsAgent } from 'agentkeepalive'
 import superagent, { Response, ResponseError, Request as SuperAgentRequest } from 'superagent'
 import { Readable } from 'stream'
@@ -9,11 +10,28 @@ import { Call, Request, RequestWithBody, StreamRequest } from './types/Request'
 import { AuthenticationClient } from './types/AuthenticationClient'
 import { RetryError, SanitisedError } from './types/Errors'
 
+const usesNodeEnvProxy = () => {
+  const majorNodeVersion = Number.parseInt(process.versions.node.split('.')[0], 10)
+
+  if (!Number.isInteger(majorNodeVersion) || majorNodeVersion < 24) {
+    return false
+  }
+
+  const nodeUseEnvProxy = process.env.NODE_USE_ENV_PROXY?.toLowerCase()
+
+  return (
+    nodeUseEnvProxy === '1' ||
+    nodeUseEnvProxy === 'true' ||
+    process.env.NODE_OPTIONS?.includes('--use-env-proxy') ||
+    process.execArgv.includes('--use-env-proxy')
+  )
+}
+
 /**
  * Base class for REST API clients.
  */
 export default class RestClient {
-  private readonly agent: HttpAgent
+  private readonly agent?: http.Agent
 
   /**
    * Creates an instance of RestClient.
@@ -29,7 +47,13 @@ export default class RestClient {
     protected readonly logger: Logger | Console,
     private readonly authenticationClient?: AuthenticationClient,
   ) {
-    this.agent = config.url.startsWith('https') ? new HttpsAgent(config.agent) : new HttpAgent(config.agent)
+    if (config.transport?.agent) {
+      this.agent = config.transport.agent
+    } else if (config.transport?.createAgent) {
+      this.agent = config.transport.createAgent({ url: config.url, agentConfig: config.agent })
+    } else if (!usesNodeEnvProxy()) {
+      this.agent = config.url.startsWith('https') ? new HttpsAgent(config.agent) : new HttpAgent(config.agent)
+    }
   }
 
   /**
@@ -151,11 +175,14 @@ export default class RestClient {
       const req = superagent
         .get(`${this.apiUrl()}${path}`)
         .query(query)
-        .agent(this.agent)
         .retry(retries, retryHandler.bind(this)())
         .set(headers)
         .responseType(responseType)
         .timeout(this.timeoutConfig())
+
+      if (this.agent) {
+        req.agent(this.agent)
+      }
 
       if (token) {
         req.auth(token, { type: 'bearer' })
@@ -207,11 +234,14 @@ export default class RestClient {
         req = superagent[method](`${this.apiUrl()}${path}`)
           .type('form')
           .query(query)
-          .agent(this.agent)
           .retry(2, retryHandler.bind(this)(retry))
           .set(headers)
           .responseType(responseType)
           .timeout(this.timeoutConfig())
+
+        if (this.agent) {
+          req.agent(this.agent)
+        }
 
         if (multipartData) {
           Object.entries(multipartData).forEach(([key, value]) => {
@@ -228,11 +258,14 @@ export default class RestClient {
         req = superagent[method](`${this.apiUrl()}${path}`)
           .query(query)
           .send(data)
-          .agent(this.agent)
           .retry(2, retryHandler.bind(this)(retry))
           .set(headers)
           .responseType(responseType)
           .timeout(this.timeoutConfig())
+
+        if (this.agent) {
+          req.agent(this.agent)
+        }
       }
 
       if (token) {
@@ -325,11 +358,14 @@ export default class RestClient {
       const req = superagent
         .delete(`${this.apiUrl()}${path}`)
         .query(query)
-        .agent(this.agent)
         .retry(retries, retryHandler.bind(this)())
         .set(headers)
         .responseType(responseType)
         .timeout(this.timeoutConfig())
+
+      if (this.agent) {
+        req.agent(this.agent)
+      }
 
       if (token) {
         req.auth(token, { type: 'bearer' })
@@ -362,10 +398,13 @@ export default class RestClient {
     return new Promise((resolve, reject) => {
       const req = superagent
         .get(`${this.apiUrl()}${path}`)
-        .agent(this.agent)
         .retry(2, this.handleRetry())
         .timeout(this.timeoutConfig())
         .set(headers)
+
+      if (this.agent) {
+        req.agent(this.agent)
+      }
 
       if (token) {
         req.auth(token, { type: 'bearer' })

--- a/packages/rest-client/src/main/RestClient.ts
+++ b/packages/rest-client/src/main/RestClient.ts
@@ -10,8 +10,10 @@ import { Call, Request, RequestWithBody, StreamRequest } from './types/Request'
 import { AuthenticationClient } from './types/AuthenticationClient'
 import { RetryError, SanitisedError } from './types/Errors'
 
+const getMajorNodeVersion = () => Number.parseInt(process.version.split('.')[0].replace('v', ''), 10)
+
 const usesNodeEnvProxy = () => {
-  const majorNodeVersion = Number.parseInt(process.versions.node.split('.')[0], 10)
+  const majorNodeVersion = getMajorNodeVersion()
 
   if (!Number.isInteger(majorNodeVersion) || majorNodeVersion < 24) {
     return false

--- a/packages/rest-client/src/main/index.ts
+++ b/packages/rest-client/src/main/index.ts
@@ -4,6 +4,7 @@ export { default as asSystem } from './helpers/asSystem'
 
 export type { ApiConfig } from './types/ApiConfig'
 export { AgentConfig } from './types/ApiConfig'
+export type { AgentOptions } from './types/ApiConfig'
 export type { TransportConfig } from './types/ApiConfig'
 
 export type { AuthOptions } from './types/AuthOptions'

--- a/packages/rest-client/src/main/index.ts
+++ b/packages/rest-client/src/main/index.ts
@@ -4,6 +4,7 @@ export { default as asSystem } from './helpers/asSystem'
 
 export type { ApiConfig } from './types/ApiConfig'
 export { AgentConfig } from './types/ApiConfig'
+export type { TransportConfig } from './types/ApiConfig'
 
 export type { AuthOptions } from './types/AuthOptions'
 

--- a/packages/rest-client/src/main/types/ApiConfig.ts
+++ b/packages/rest-client/src/main/types/ApiConfig.ts
@@ -1,4 +1,5 @@
 import type http from 'http'
+import type { HttpOptions, HttpsOptions } from 'agentkeepalive'
 
 export class AgentConfig {
   // Sets the working socket to timeout after timeout milliseconds of inactivity on the working socket.
@@ -8,6 +9,8 @@ export class AgentConfig {
     this.timeout = timeout
   }
 }
+
+export type AgentOptions = AgentConfig | HttpOptions | HttpsOptions
 
 export interface TransportConfig {
   /**
@@ -24,7 +27,7 @@ export interface TransportConfig {
    * auto-detection. The caller is responsible for ensuring the supplied agent is compatible with any required
    * proxying.
    */
-  createAgent?: (options: { url: string; agentConfig: AgentConfig }) => http.Agent
+  createAgent?: (options: { url: string; agentConfig: AgentOptions }) => http.Agent
 }
 
 export interface ApiConfig {
@@ -37,6 +40,6 @@ export interface ApiConfig {
     // If the response isn't fully downloaded within that time, the request will be aborted.
     deadline: number
   }
-  agent: AgentConfig
+  agent: AgentOptions
   transport?: TransportConfig
 }

--- a/packages/rest-client/src/main/types/ApiConfig.ts
+++ b/packages/rest-client/src/main/types/ApiConfig.ts
@@ -40,6 +40,17 @@ export interface ApiConfig {
     // If the response isn't fully downloaded within that time, the request will be aborted.
     deadline: number
   }
+  /**
+   * Configuration for the default keepalive agent created by hmpps-rest-client.
+   *
+   * This is ignored when `transport.agent` or `transport.createAgent` is supplied, and it is also ignored when Node
+   * env proxy mode is active and no explicit transport override is configured.
+   */
   agent: AgentOptions
+  /**
+   * Explicit transport override for callers that need to supply or construct their own agent.
+   *
+   * `transport.agent` and `transport.createAgent` take precedence over `agent`.
+   */
   transport?: TransportConfig
 }

--- a/packages/rest-client/src/main/types/ApiConfig.ts
+++ b/packages/rest-client/src/main/types/ApiConfig.ts
@@ -1,3 +1,5 @@
+import type http from 'http'
+
 export class AgentConfig {
   // Sets the working socket to timeout after timeout milliseconds of inactivity on the working socket.
   timeout: number
@@ -5,6 +7,24 @@ export class AgentConfig {
   constructor(timeout = 8000) {
     this.timeout = timeout
   }
+}
+
+export interface TransportConfig {
+  /**
+   * Explicit agent instance to use for all requests.
+   *
+   * When provided, the rest client will always use this agent, even when Node env proxy mode is enabled.
+   * The caller is responsible for ensuring the supplied agent is compatible with any required proxying.
+   */
+  agent?: http.Agent
+  /**
+   * Factory for creating an explicit agent instance.
+   *
+   * This is evaluated during client construction and overrides both the default keepalive agent and Node env proxy
+   * auto-detection. The caller is responsible for ensuring the supplied agent is compatible with any required
+   * proxying.
+   */
+  createAgent?: (options: { url: string; agentConfig: AgentConfig }) => http.Agent
 }
 
 export interface ApiConfig {
@@ -18,4 +38,5 @@ export interface ApiConfig {
     deadline: number
   }
   agent: AgentConfig
+  transport?: TransportConfig
 }

--- a/packages/rest-client/src/main/types/Request.ts
+++ b/packages/rest-client/src/main/types/Request.ts
@@ -51,7 +51,7 @@ export interface StreamRequest<ErrorData> {
 export interface CallContext {
   superagent: superagent.SuperAgent
   token: string | undefined
-  agent: http.Agent
+  agent?: http.Agent
 }
 
 export interface Call<Response = unknown> {


### PR DESCRIPTION
## Summary
- make `hmpps-rest-client` proxy-aware by deferring to Node env-proxy mode on supported runtimes instead of always constructing a keepalive agent
- add explicit transport overrides to `hmpps-rest-client` for callers that need to supply or create their own agent
- update `hmpps-monitoring` health checks to pass through `agent`, legacy `agentConfig`, and `transport` settings to the underlying rest client
- clarify transport and option precedence in the public types so callers can see when explicit transport overrides win

## Root cause
`hmpps-prisoner-pay-ui` was already wiring `/health` through `@ministryofjustice/hmpps-monitoring` and already setting `NODE_USE_ENV_PROXY=1` plus the required proxy environment variables in Helm.

The missing behaviour was upstream in `hmpps-typescript-lib`:
- `@ministryofjustice/hmpps-rest-client` `1.2.1` always created an explicit `HttpAgent` or `HttpsAgent`, which bypassed Node env-proxy mode
- `@ministryofjustice/hmpps-monitoring` `1.1.0` created its own `RestClient` for health checks but did not pass through the same transport inputs that application API clients could already use

That meant downstream API traffic and health-check traffic could take different transport paths, so the UI health checks were the remaining proxy gap.

## Notes
- `hmpps-rest-client` still falls back to an explicit agent on Node 20 and 22, where Node env-proxy mode is not available
- `hmpps-monitoring` keeps `agentConfig` as a backwards-compatible alias while preferring `agent`
- explicit `transport.agent` and `transport.createAgent` take precedence over default agent options
