### PR TITLE
(WIP) Proxy-Aware keepalive agents from node v24

### DIFF
--- a/packages/monitoring/CHANGELOG.md
+++ b/packages/monitoring/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.0
 
-Add proxy-aware health check transport options, including support for preferred `agent`, legacy `agentConfig`, and explicit `transport` overrides that pass through to `@ministryofjustice/hmpps-rest-client`.
+Add support for preferred `agent` health-check options while retaining legacy `agentConfig` compatibility.
 
 ## 1.1.0
 

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
@@ -1,4 +1,3 @@
-import http from 'http'
 import { createTestNock } from '../../test/utils'
 import EndpointHealthComponent from './EndpointHealthComponent'
 import type { EndpointHealthComponentOptions } from '../types/EndpointHealthComponentOptions'
@@ -7,18 +6,6 @@ describe('EndpointHealthComponent', () => {
   let nock: ReturnType<typeof createTestNock>
   const componentName = 'test-component'
   let endpointHealthComponentOptions: EndpointHealthComponentOptions
-  const originalNodeUseEnvProxy = process.env.NODE_USE_ENV_PROXY
-  const originalNodeOptions = process.env.NODE_OPTIONS
-  const [, major = '0'] = process.version.match(/^v(\d+)\.(\d+)\.(\d+)/) ?? []
-  const nodeSupportsEnvProxy = Number(major) >= 24
-
-  const restoreEnvVar = (name: 'NODE_USE_ENV_PROXY' | 'NODE_OPTIONS', value: string | undefined) => {
-    if (value === undefined) {
-      delete process.env[name]
-    } else {
-      process.env[name] = value
-    }
-  }
 
   const messages = jest.fn()
   const logger = {
@@ -27,7 +14,8 @@ describe('EndpointHealthComponent', () => {
   } as unknown as jest.Mocked<Console>
 
   const getInternalAgent = (component: EndpointHealthComponent) =>
-    (component as unknown as { healthClient: { agent?: unknown } }).healthClient.agent
+    (component as unknown as { healthClient: { agent: { options: { timeout?: number; maxSockets?: number } } } })
+      .healthClient.agent
 
   beforeEach(() => {
     nock = createTestNock({ method: 'get', baseUrl: 'https://test.local', path: '/some-path' })
@@ -42,69 +30,21 @@ describe('EndpointHealthComponent', () => {
   })
 
   afterEach(() => {
-    restoreEnvVar('NODE_USE_ENV_PROXY', originalNodeUseEnvProxy)
-    restoreEnvVar('NODE_OPTIONS', originalNodeOptions)
     nock.done()
   })
 
-  it('only defers to Node env proxy mode when the runtime supports it', () => {
-    process.env.NODE_USE_ENV_PROXY = '1'
-
-    const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
-
-    if (nodeSupportsEnvProxy) {
-      expect(getInternalAgent(endpointHealthComponent)).toBeUndefined()
-    } else {
-      expect(getInternalAgent(endpointHealthComponent)).toBeDefined()
-    }
-  })
-
-  it('uses an explicitly supplied custom agent when Node env proxy mode is enabled', () => {
-    process.env.NODE_USE_ENV_PROXY = '1'
-
-    const customAgent = new http.Agent({ keepAlive: true, timeout: 6543 })
-    endpointHealthComponentOptions = { ...endpointHealthComponentOptions, transport: { agent: customAgent } }
-
-    const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
-
-    expect(getInternalAgent(endpointHealthComponent)).toBe(customAgent)
-  })
-
-  it('uses a custom agent created by transport.createAgent when Node env proxy mode is enabled', () => {
-    process.env.NODE_USE_ENV_PROXY = '1'
-
-    const customAgent = new http.Agent({ keepAlive: true, timeout: 7654 })
-    const createAgent = jest.fn().mockReturnValue(customAgent)
-    endpointHealthComponentOptions = { ...endpointHealthComponentOptions, transport: { createAgent } }
-
-    const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
-
-    expect(createAgent).toHaveBeenCalledWith({
-      url: nock.baseUrl,
-      healthPath: nock.uniquePath,
-      agentConfig: expect.objectContaining({ timeout: 8000 }),
-    })
-    expect(getInternalAgent(endpointHealthComponent)).toBe(customAgent)
-  })
-
-  it('preserves legacy agentConfig options when creating a custom transport agent', () => {
-    const customAgent = new http.Agent({ keepAlive: true, timeout: 7654 })
-    const createAgent = jest.fn().mockReturnValue(customAgent)
-
+  it('preserves legacy agentConfig options', () => {
     endpointHealthComponentOptions = {
       ...endpointHealthComponentOptions,
       agentConfig: { timeout: 4321, maxSockets: 7 },
-      transport: { createAgent },
     }
 
     const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
 
-    expect(createAgent).toHaveBeenCalledWith({
-      url: nock.baseUrl,
-      healthPath: nock.uniquePath,
-      agentConfig: expect.objectContaining({ timeout: 4321, maxSockets: 7 }),
+    expect(getInternalAgent(endpointHealthComponent).options).toMatchObject({
+      timeout: 4321,
+      maxSockets: 7,
     })
-    expect(getInternalAgent(endpointHealthComponent)).toBe(customAgent)
   })
 
   it('accepts agent options under the agent field', () => {
@@ -115,9 +55,7 @@ describe('EndpointHealthComponent', () => {
 
     const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
 
-    expect(
-      (getInternalAgent(endpointHealthComponent) as { options: { timeout?: number; maxSockets?: number } }).options,
-    ).toMatchObject({
+    expect(getInternalAgent(endpointHealthComponent).options).toMatchObject({
       timeout: 4321,
       maxSockets: 7,
     })

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.test.ts
@@ -63,7 +63,7 @@ describe('EndpointHealthComponent', () => {
     process.env.NODE_USE_ENV_PROXY = '1'
 
     const customAgent = new http.Agent({ keepAlive: true, timeout: 6543 })
-    endpointHealthComponentOptions.transport = { agent: customAgent }
+    endpointHealthComponentOptions = { ...endpointHealthComponentOptions, transport: { agent: customAgent } }
 
     const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
 
@@ -75,7 +75,7 @@ describe('EndpointHealthComponent', () => {
 
     const customAgent = new http.Agent({ keepAlive: true, timeout: 7654 })
     const createAgent = jest.fn().mockReturnValue(customAgent)
-    endpointHealthComponentOptions.transport = { createAgent }
+    endpointHealthComponentOptions = { ...endpointHealthComponentOptions, transport: { createAgent } }
 
     const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
 
@@ -91,8 +91,11 @@ describe('EndpointHealthComponent', () => {
     const customAgent = new http.Agent({ keepAlive: true, timeout: 7654 })
     const createAgent = jest.fn().mockReturnValue(customAgent)
 
-    endpointHealthComponentOptions.agentConfig = { timeout: 4321, maxSockets: 7 }
-    endpointHealthComponentOptions.transport = { createAgent }
+    endpointHealthComponentOptions = {
+      ...endpointHealthComponentOptions,
+      agentConfig: { timeout: 4321, maxSockets: 7 },
+      transport: { createAgent },
+    }
 
     const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
 
@@ -105,7 +108,10 @@ describe('EndpointHealthComponent', () => {
   })
 
   it('accepts agent options under the agent field', () => {
-    endpointHealthComponentOptions.agent = { timeout: 4321, maxSockets: 7 }
+    endpointHealthComponentOptions = {
+      ...endpointHealthComponentOptions,
+      agent: { timeout: 4321, maxSockets: 7 },
+    }
 
     const endpointHealthComponent = new EndpointHealthComponent(logger, componentName, endpointHealthComponentOptions)
 

--- a/packages/monitoring/src/main/components/EndpointHealthComponent.ts
+++ b/packages/monitoring/src/main/components/EndpointHealthComponent.ts
@@ -4,7 +4,6 @@ import {
   type AgentOptions,
   type ApiConfig,
   type SanitisedError,
-  type TransportConfig,
 } from '@ministryofjustice/hmpps-rest-client'
 import type { Response as SuperAgentResponse } from 'superagent'
 // annoyingly, eslint doesn't automatically consider @types/bunyuan a dev depdendency, it's not even directly referenced here
@@ -142,8 +141,6 @@ export default class EndpointHealthComponent implements HealthComponent {
   }
 
   private createApiConfig(options: EndpointHealthComponentOptions): ApiConfig {
-    const transportOptions = options.transport
-    const createAgent = transportOptions?.createAgent
     const resolvedAgentConfig: AgentOptions = options.agent ?? options.agentConfig ?? new AgentConfig()
     const timeout =
       typeof options.timeout === 'number'
@@ -152,27 +149,11 @@ export default class EndpointHealthComponent implements HealthComponent {
             response: options.timeout?.response ?? this.defaultOptions.timeout.response,
             deadline: options.timeout?.deadline ?? this.defaultOptions.timeout.deadline,
           }
-    const transportCreateAgent = createAgent
-      ? ({ url, agentConfig }: { url: string; agentConfig: AgentOptions }) =>
-          createAgent({
-            url,
-            healthPath: options.healthPath,
-            agentConfig,
-          })
-      : undefined
-
-    const transport: TransportConfig | undefined = transportOptions
-      ? {
-          agent: transportOptions.agent,
-          createAgent: transportCreateAgent,
-        }
-      : undefined
 
     return {
       url: options.url,
       timeout,
       agent: resolvedAgentConfig,
-      transport,
     }
   }
 

--- a/packages/monitoring/src/main/index.ts
+++ b/packages/monitoring/src/main/index.ts
@@ -28,4 +28,3 @@ export function endpointHealthComponent(...args: ConstructorParameters<typeof En
 
 export type { HealthComponent, ComponentHealthResult } from './types/HealthComponent'
 export type { EndpointHealthComponentOptions } from './types/EndpointHealthComponentOptions'
-export type { EndpointHealthTransportOptions } from './types/EndpointHealthComponentOptions'

--- a/packages/monitoring/src/main/types/EndpointHealthComponentOptions.ts
+++ b/packages/monitoring/src/main/types/EndpointHealthComponentOptions.ts
@@ -18,7 +18,7 @@ export interface EndpointHealthTransportOptions extends Omit<TransportConfig, 'c
   createAgent?: (options: { url: string; healthPath: string; agentConfig?: AgentOptions }) => http.Agent
 }
 
-export interface EndpointHealthComponentOptions {
+type EndpointHealthSharedOptions = {
   /** The root URL of the external service to be health-checked. */
   url: string
   /** The path that represents the endpoint that will be called on the external service to be health-checked. The full endpoint url that will be called is `${url}${healthPath}`. */
@@ -34,12 +34,21 @@ export interface EndpointHealthComponentOptions {
       }
   /** (Optional) The number of retry attempts for the component's health check. Defaults to 2 */
   retries?: number
+}
+
+type EndpointHealthDefaultOptions = EndpointHealthSharedOptions & {
+  agent?: undefined
+  agentConfig?: undefined
+  transport?: undefined
+}
+
+type EndpointHealthAgentOptions = EndpointHealthSharedOptions & {
   /**
    * (Optional) Preferred agent configuration options for HTTP/HTTPS requests to the service.
    *
    * When both `agent` and `agentConfig` are supplied, `agent` takes precedence.
    */
-  agent?: AgentOptions
+  agent: AgentOptions
   /**
    * (Optional) Legacy alias for `agent`.
    *
@@ -47,10 +56,33 @@ export interface EndpointHealthComponentOptions {
    * precedence.
    */
   agentConfig?: AgentOptions
+  transport?: undefined
+}
+
+type EndpointHealthLegacyAgentConfigOptions = EndpointHealthSharedOptions & {
+  agent?: undefined
+  /**
+   * (Optional) Legacy alias for `agent`.
+   *
+   * This is retained for backwards compatibility.
+   */
+  agentConfig: AgentOptions
+  transport?: undefined
+}
+
+type EndpointHealthTransportOverrideComponentOptions = EndpointHealthSharedOptions & {
+  agent?: AgentOptions
+  agentConfig?: AgentOptions
   /**
    * (Optional) Explicit transport override for health checks.
    *
    * `transport.agent` and `transport.createAgent` take precedence over both `agent` and `agentConfig`.
    */
-  transport?: EndpointHealthTransportOptions
+  transport: EndpointHealthTransportOptions
 }
+
+export type EndpointHealthComponentOptions =
+  | EndpointHealthDefaultOptions
+  | EndpointHealthAgentOptions
+  | EndpointHealthLegacyAgentConfigOptions
+  | EndpointHealthTransportOverrideComponentOptions

--- a/packages/monitoring/src/main/types/EndpointHealthComponentOptions.ts
+++ b/packages/monitoring/src/main/types/EndpointHealthComponentOptions.ts
@@ -1,24 +1,6 @@
-import type { AgentOptions, TransportConfig } from '@ministryofjustice/hmpps-rest-client'
-import type http from 'http'
+import type { AgentOptions } from '@ministryofjustice/hmpps-rest-client'
 
-export interface EndpointHealthTransportOptions extends Omit<TransportConfig, 'createAgent'> {
-  /**
-   * Explicit agent instance to use for health checks.
-   *
-   * When provided, the monitoring package will always use this agent, even when Node env proxy mode is enabled.
-   * The caller is responsible for ensuring the supplied agent is compatible with any required proxying.
-   */
-  agent?: http.Agent
-  /**
-   * Factory for creating an explicit health-check agent.
-   *
-   * This overrides both the default keepalive agent and Node env proxy auto-detection. The caller is responsible for
-   * ensuring the supplied agent is compatible with any required proxying.
-   */
-  createAgent?: (options: { url: string; healthPath: string; agentConfig?: AgentOptions }) => http.Agent
-}
-
-type EndpointHealthSharedOptions = {
+export interface EndpointHealthComponentOptions {
   /** The root URL of the external service to be health-checked. */
   url: string
   /** The path that represents the endpoint that will be called on the external service to be health-checked. The full endpoint url that will be called is `${url}${healthPath}`. */
@@ -34,21 +16,12 @@ type EndpointHealthSharedOptions = {
       }
   /** (Optional) The number of retry attempts for the component's health check. Defaults to 2 */
   retries?: number
-}
-
-type EndpointHealthDefaultOptions = EndpointHealthSharedOptions & {
-  agent?: undefined
-  agentConfig?: undefined
-  transport?: undefined
-}
-
-type EndpointHealthAgentOptions = EndpointHealthSharedOptions & {
   /**
    * (Optional) Preferred agent configuration options for HTTP/HTTPS requests to the service.
    *
    * When both `agent` and `agentConfig` are supplied, `agent` takes precedence.
    */
-  agent: AgentOptions
+  agent?: AgentOptions
   /**
    * (Optional) Legacy alias for `agent`.
    *
@@ -56,33 +29,4 @@ type EndpointHealthAgentOptions = EndpointHealthSharedOptions & {
    * precedence.
    */
   agentConfig?: AgentOptions
-  transport?: undefined
 }
-
-type EndpointHealthLegacyAgentConfigOptions = EndpointHealthSharedOptions & {
-  agent?: undefined
-  /**
-   * (Optional) Legacy alias for `agent`.
-   *
-   * This is retained for backwards compatibility.
-   */
-  agentConfig: AgentOptions
-  transport?: undefined
-}
-
-type EndpointHealthTransportOverrideComponentOptions = EndpointHealthSharedOptions & {
-  agent?: AgentOptions
-  agentConfig?: AgentOptions
-  /**
-   * (Optional) Explicit transport override for health checks.
-   *
-   * `transport.agent` and `transport.createAgent` take precedence over both `agent` and `agentConfig`.
-   */
-  transport: EndpointHealthTransportOptions
-}
-
-export type EndpointHealthComponentOptions =
-  | EndpointHealthDefaultOptions
-  | EndpointHealthAgentOptions
-  | EndpointHealthLegacyAgentConfigOptions
-  | EndpointHealthTransportOverrideComponentOptions

--- a/packages/rest-client/CHANGELOG.md
+++ b/packages/rest-client/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change log
 
 # 1.3.0
-- Add proxy-aware transport handling so the client defers to Node env-proxy mode on supported runtimes instead of always constructing a keepalive agent.
-- Add `transport.agent` and `transport.createAgent` overrides for callers that need to supply or construct their own agent.
+- Allow proxy-aware keepalive agent options to be passed through to the underlying `agentkeepalive` agent.
+- Warn when proxy-aware keepalive agent settings are configured on Node.js versions earlier than v24.
 
 # 1.1.0
 - Add support for multipart form data requests [PR-143](https://github.com/ministryofjustice/hmpps-typescript-lib/pull/143)

--- a/packages/rest-client/README.md
+++ b/packages/rest-client/README.md
@@ -86,6 +86,31 @@ const authClient = new AuthenticationClient(config.apis.hmppsAuth, logger, token
 const client = new ExampleApiClient(authClient)
 ```
 
+### Proxy-Aware Keepalive Agents
+
+If you need outbound requests to use a proxy while still reusing keepalive sockets, pass proxy settings as part of the
+`agent` configuration.
+
+```ts
+const apiConfig: ApiConfig = {
+  url: 'https://example.com/api',
+  timeout: {
+    response: 5000,
+    deadline: 10000,
+  },
+  agent: {
+    timeout: 5000,
+    proxyEnv: {
+      HTTPS_PROXY: process.env.HTTPS_PROXY,
+      NO_PROXY: process.env.NO_PROXY,
+    },
+  },
+}
+```
+
+Proxy-aware keepalive agent settings rely on Node.js v24 or later. On earlier Node.js versions, hmpps-rest-client
+will log a warning because proxy settings may be ignored by the runtime.
+
 ### Authentication
 
 This library accepts an optional `AuthenticationClient` provider which implements

--- a/packages/rest-client/src/main/RestClient.test.ts
+++ b/packages/rest-client/src/main/RestClient.test.ts
@@ -1,5 +1,4 @@
 import nock from 'nock'
-import http from 'http'
 import express from 'express'
 import { Response } from 'superagent'
 import { PassThrough } from 'stream'
@@ -28,18 +27,10 @@ class TestRestClient extends RestClient {
 }
 
 const restClient = new TestRestClient()
-const originalNodeUseEnvProxy = process.env.NODE_USE_ENV_PROXY
-const originalNodeOptions = process.env.NODE_OPTIONS
-const [, major = '0'] = process.version.match(/^v(\d+)\.(\d+)\.(\d+)/) ?? []
-const nodeSupportsEnvProxy = Number(major) >= 24
+const originalNodeVersion = process.version
 
-const restoreEnvVar = (name: 'NODE_USE_ENV_PROXY' | 'NODE_OPTIONS', value: string | undefined) => {
-  if (value === undefined) {
-    delete process.env[name]
-  } else {
-    process.env[name] = value
-  }
-}
+const setNodeVersion = (nodeVersion: string) =>
+  Object.defineProperty(process, 'version', { value: nodeVersion, configurable: true })
 
 const systemAuthOptions: AuthOptions = {
   tokenType: TokenType.SYSTEM_TOKEN,
@@ -70,49 +61,45 @@ describe('RestClient', () => {
   const getInternalAgent = (client: RestClient) => (client as unknown as { agent?: unknown }).agent
 
   afterEach(() => {
-    restoreEnvVar('NODE_USE_ENV_PROXY', originalNodeUseEnvProxy)
-    restoreEnvVar('NODE_OPTIONS', originalNodeOptions)
+    setNodeVersion(originalNodeVersion)
+    jest.restoreAllMocks()
   })
 
-  it('only defers to Node env proxy mode when the runtime supports it', () => {
-    process.env.NODE_USE_ENV_PROXY = '1'
-
-    const client = new TestRestClient()
-
-    if (nodeSupportsEnvProxy) {
-      expect(getInternalAgent(client)).toBeUndefined()
-    } else {
-      expect(getInternalAgent(client)).toBeDefined()
+  it('passes proxy settings through to the underlying keepalive agent', () => {
+    const proxyEnv = {
+      HTTPS_PROXY: 'http://envoy.local:3128',
+      NO_PROXY: 'localhost,127.0.0.1',
     }
-  })
-
-  it('uses an explicitly supplied transport agent when Node env proxy mode is enabled', () => {
-    process.env.NODE_USE_ENV_PROXY = '1'
-
-    const customAgent = new http.Agent({ keepAlive: true, timeout: 6543 })
     const client = new TestRestClient({
       ...baseApiConfig,
-      transport: { agent: customAgent },
+      agent: {
+        timeout: 6543,
+        proxyEnv,
+      },
     })
 
-    expect(getInternalAgent(client)).toBe(customAgent)
+    expect(
+      (getInternalAgent(client) as { options: { proxyEnv?: typeof proxyEnv; timeout?: number } }).options,
+    ).toMatchObject({ timeout: 6543, proxyEnv })
   })
 
-  it('uses a transport.createAgent factory when Node env proxy mode is enabled', () => {
-    process.env.NODE_USE_ENV_PROXY = '1'
+  it('warns when proxy settings are configured on runtimes before Node.js v24', () => {
+    setNodeVersion('v22.11.0')
 
-    const customAgent = new http.Agent({ keepAlive: true, timeout: 7654 })
-    const createAgent = jest.fn().mockReturnValue(customAgent)
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+
     const client = new TestRestClient({
       ...baseApiConfig,
-      transport: { createAgent },
+      agent: {
+        timeout: 7654,
+        proxyEnv: { HTTPS_PROXY: 'http://envoy.local:3128' },
+      },
     })
 
-    expect(createAgent).toHaveBeenCalledWith({
-      url: baseApiConfig.url,
-      agentConfig: baseApiConfig.agent,
-    })
-    expect(getInternalAgent(client)).toBe(customAgent)
+    expect(client).toBeDefined()
+    expect(warn).toHaveBeenCalledWith(
+      "Proxy-aware keepalive agent settings for 'api-name' require Node.js v24 or later. Detected v22.11.0; configured proxy settings may be ignored on this runtime.",
+    )
   })
 
   describe.each(['get', 'patch', 'post', 'put', 'delete'] as const)('%s', method => {
@@ -677,15 +664,10 @@ describe('RestClient', () => {
       const receivedData = await restClient.makeRestClientCall<string>(
         systemAuthOptions,
         async ({ superagent, token, agent }: CallContext): Promise<string> => {
-          const request = superagent
+          const result = await superagent
             .get(`http://localhost:8080/api/some-path`)
             .auth(token as string, { type: 'bearer' })
-
-          if (agent) {
-            request.agent(agent)
-          }
-
-          const result = await request
+            .agent(agent)
 
           return result.body.message
         },

--- a/packages/rest-client/src/main/RestClient.ts
+++ b/packages/rest-client/src/main/RestClient.ts
@@ -9,16 +9,17 @@ import { AuthOptions, TokenType } from './types/AuthOptions'
 import { Call, Request, RequestWithBody, StreamRequest } from './types/Request'
 import { AuthenticationClient } from './types/AuthenticationClient'
 import { RetryError, SanitisedError } from './types/Errors'
+import type { AgentOptions } from './types/ApiConfig'
 
 const getMajorNodeVersion = () => Number.parseInt(process.version.split('.')[0].replace('v', ''), 10)
 
-const usesNodeEnvProxy = () => {
+const runtimeSupportsProxyAwareAgents = () => {
   const majorNodeVersion = getMajorNodeVersion()
 
-  if (!Number.isInteger(majorNodeVersion) || majorNodeVersion < 24) {
-    return false
-  }
+  return Number.isInteger(majorNodeVersion) && majorNodeVersion >= 24
+}
 
+const usesNodeEnvProxy = () => {
   const nodeUseEnvProxy = process.env.NODE_USE_ENV_PROXY?.toLowerCase()
 
   return (
@@ -29,11 +30,34 @@ const usesNodeEnvProxy = () => {
   )
 }
 
+const hasConfiguredProxyEnv = (agentOptions: AgentOptions) => {
+  const { proxyEnv } = agentOptions as AgentOptions & { proxyEnv?: NodeJS.ProcessEnv }
+
+  return Object.values(proxyEnv ?? {}).some(value => Boolean(value))
+}
+
+let hasWarnedAboutUnsupportedProxyConfiguration = false
+
+const warnIfUnsupportedProxyConfiguration = (name: string, agentOptions: AgentOptions, logger: Logger | Console) => {
+  if (runtimeSupportsProxyAwareAgents() || hasWarnedAboutUnsupportedProxyConfiguration) {
+    return
+  }
+
+  if (!hasConfiguredProxyEnv(agentOptions) && !usesNodeEnvProxy()) {
+    return
+  }
+
+  hasWarnedAboutUnsupportedProxyConfiguration = true
+  logger.warn(
+    `Proxy-aware keepalive agent settings for '${name}' require Node.js v24 or later. Detected ${process.version}; configured proxy settings may be ignored on this runtime.`,
+  )
+}
+
 /**
  * Base class for REST API clients.
  */
 export default class RestClient {
-  private readonly agent?: http.Agent
+  private readonly agent: http.Agent
 
   /**
    * Creates an instance of RestClient.
@@ -49,13 +73,8 @@ export default class RestClient {
     protected readonly logger: Logger | Console,
     private readonly authenticationClient?: AuthenticationClient,
   ) {
-    if (config.transport?.agent) {
-      this.agent = config.transport.agent
-    } else if (config.transport?.createAgent) {
-      this.agent = config.transport.createAgent({ url: config.url, agentConfig: config.agent })
-    } else if (!usesNodeEnvProxy()) {
-      this.agent = config.url.startsWith('https') ? new HttpsAgent(config.agent) : new HttpAgent(config.agent)
-    }
+    warnIfUnsupportedProxyConfiguration(name, config.agent, logger)
+    this.agent = config.url.startsWith('https') ? new HttpsAgent(config.agent) : new HttpAgent(config.agent)
   }
 
   /**
@@ -177,14 +196,11 @@ export default class RestClient {
       const req = superagent
         .get(`${this.apiUrl()}${path}`)
         .query(query)
+        .agent(this.agent)
         .retry(retries, retryHandler.bind(this)())
         .set(headers)
         .responseType(responseType)
         .timeout(this.timeoutConfig())
-
-      if (this.agent) {
-        req.agent(this.agent)
-      }
 
       if (token) {
         req.auth(token, { type: 'bearer' })
@@ -236,14 +252,11 @@ export default class RestClient {
         req = superagent[method](`${this.apiUrl()}${path}`)
           .type('form')
           .query(query)
+          .agent(this.agent)
           .retry(2, retryHandler.bind(this)(retry))
           .set(headers)
           .responseType(responseType)
           .timeout(this.timeoutConfig())
-
-        if (this.agent) {
-          req.agent(this.agent)
-        }
 
         if (multipartData) {
           Object.entries(multipartData).forEach(([key, value]) => {
@@ -260,14 +273,11 @@ export default class RestClient {
         req = superagent[method](`${this.apiUrl()}${path}`)
           .query(query)
           .send(data)
+          .agent(this.agent)
           .retry(2, retryHandler.bind(this)(retry))
           .set(headers)
           .responseType(responseType)
           .timeout(this.timeoutConfig())
-
-        if (this.agent) {
-          req.agent(this.agent)
-        }
       }
 
       if (token) {
@@ -360,14 +370,11 @@ export default class RestClient {
       const req = superagent
         .delete(`${this.apiUrl()}${path}`)
         .query(query)
+        .agent(this.agent)
         .retry(retries, retryHandler.bind(this)())
         .set(headers)
         .responseType(responseType)
         .timeout(this.timeoutConfig())
-
-      if (this.agent) {
-        req.agent(this.agent)
-      }
 
       if (token) {
         req.auth(token, { type: 'bearer' })
@@ -400,13 +407,10 @@ export default class RestClient {
     return new Promise((resolve, reject) => {
       const req = superagent
         .get(`${this.apiUrl()}${path}`)
+        .agent(this.agent)
         .retry(2, this.handleRetry())
         .timeout(this.timeoutConfig())
         .set(headers)
-
-      if (this.agent) {
-        req.agent(this.agent)
-      }
 
       if (token) {
         req.auth(token, { type: 'bearer' })

--- a/packages/rest-client/src/main/index.ts
+++ b/packages/rest-client/src/main/index.ts
@@ -5,7 +5,6 @@ export { default as asSystem } from './helpers/asSystem'
 export type { ApiConfig } from './types/ApiConfig'
 export { AgentConfig } from './types/ApiConfig'
 export type { AgentOptions } from './types/ApiConfig'
-export type { TransportConfig } from './types/ApiConfig'
 
 export type { AuthOptions } from './types/AuthOptions'
 

--- a/packages/rest-client/src/main/types/ApiConfig.ts
+++ b/packages/rest-client/src/main/types/ApiConfig.ts
@@ -1,4 +1,3 @@
-import type http from 'http'
 import type { HttpOptions, HttpsOptions } from 'agentkeepalive'
 
 export class AgentConfig {
@@ -12,24 +11,6 @@ export class AgentConfig {
 
 export type AgentOptions = AgentConfig | HttpOptions | HttpsOptions
 
-export interface TransportConfig {
-  /**
-   * Explicit agent instance to use for all requests.
-   *
-   * When provided, the rest client will always use this agent, even when Node env proxy mode is enabled.
-   * The caller is responsible for ensuring the supplied agent is compatible with any required proxying.
-   */
-  agent?: http.Agent
-  /**
-   * Factory for creating an explicit agent instance.
-   *
-   * This is evaluated during client construction and overrides both the default keepalive agent and Node env proxy
-   * auto-detection. The caller is responsible for ensuring the supplied agent is compatible with any required
-   * proxying.
-   */
-  createAgent?: (options: { url: string; agentConfig: AgentOptions }) => http.Agent
-}
-
 export interface ApiConfig {
   url: string
   timeout: {
@@ -41,16 +22,11 @@ export interface ApiConfig {
     deadline: number
   }
   /**
-   * Configuration for the default keepalive agent created by hmpps-rest-client.
+   * Configuration for the keepalive agent created by hmpps-rest-client.
    *
-   * This is ignored when `transport.agent` or `transport.createAgent` is supplied, and it is also ignored when Node
-   * env proxy mode is active and no explicit transport override is configured.
+   * On Node.js v24 and later, proxy-aware settings such as `proxyEnv` are passed through to the underlying keepalive
+   * agent. On earlier Node.js versions, hmpps-rest-client will log a warning if proxy settings are configured because
+   * they may be ignored by the runtime.
    */
   agent: AgentOptions
-  /**
-   * Explicit transport override for callers that need to supply or construct their own agent.
-   *
-   * `transport.agent` and `transport.createAgent` take precedence over `agent`.
-   */
-  transport?: TransportConfig
 }

--- a/packages/rest-client/src/main/types/Request.ts
+++ b/packages/rest-client/src/main/types/Request.ts
@@ -51,7 +51,7 @@ export interface StreamRequest<ErrorData> {
 export interface CallContext {
   superagent: superagent.SuperAgent
   token: string | undefined
-  agent?: http.Agent
+  agent: http.Agent
 }
 
 export interface Call<Response = unknown> {


### PR DESCRIPTION
## Summary
- prototype a named union-type version of `EndpointHealthComponentOptions`
- keep the runtime behaviour unchanged while making the supported option shapes more explicit in the type definition
- adjust the monitoring test setup so it reassigns whole option objects instead of mutating union-typed properties in place

## Why
This is a follow-up to the review suggestion that the current `EndpointHealthComponentOptions` shape is hard to read because it exposes `agent`, `agentConfig`, and `transport` together in a single interface.

This branch explores whether named union variants make the supported configurations easier to understand without changing the underlying transport behaviour.

## Notes
- this PR is intentionally targeted at `fix-healthcheck-proxying`, not `main`
- runtime behaviour is unchanged; this is a type-shape experiment only
- the current implementation still allows the transport override path to take precedence at runtime
