### PR TITLE
Update pre-commit hooks

### DIFF
--- a/packages/precommit-hooks/CHANGELOG.md
+++ b/packages/precommit-hooks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 3.0.1
+
+Excludes snapshot test files from trailing-whitespace hook
+
 ## 3.0.0
 
 Drops support for node engine 20 (no longer maintained) and adds 26 (will be LTS later this year).

--- a/packages/precommit-hooks/default-hooks.yaml
+++ b/packages/precommit-hooks/default-hooks.yaml
@@ -40,6 +40,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+        exclude: ^.*snap$
       - id: check-json
       - id: check-yaml
       - id: check-merge-conflict

--- a/packages/precommit-hooks/package.json
+++ b/packages/precommit-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-precommit-hooks",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Precommit hooks for HMPPS typescript projects",
   "keywords": [
     "precommit"


### PR DESCRIPTION
Exclude snapshot files from trailing whitespace checks in pre-commit since npm has specific spacing when creating snapshots