### PR TITLE
Update `@ministryofjustice/hmpps-auth-clients` to use redis library v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1472,7 +1472,9 @@
       }
     },
     "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1985,58 +1987,80 @@
       }
     },
     "node_modules/@redis/bloom": {
-      "version": "5.10.0",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-6.0.0.tgz",
+      "integrity": "sha512-P0n5NkV9IIdT6nYXOfMHG83sho8pE7Nay7yw27wOGVLv4DthgvzebpGz6m7VuMTizeJmw3LPw2Xek5wFUhGpVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^6.0.0"
       }
     },
     "node_modules/@redis/client": {
-      "version": "5.10.0",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-6.0.0.tgz",
+      "integrity": "sha512-NS4iIT25r24sAjNQ2nSRdCW5jPJoV0rxkBee27oTeR+RXaOu89cjIsrww5rPBaYVGVdL1QCx9uz9141gZiSKdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@redis/json": {
-      "version": "5.10.0",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-6.0.0.tgz",
+      "integrity": "sha512-F+eqFfgPcy57Zs1KW7UtLnBtRk6lxAUIoe7dyZerpm6e+ssYXG/dWJrbrHFYs0b7tt6QBtYpVuukBuM9XqhUAg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^6.0.0"
       }
     },
     "node_modules/@redis/search": {
-      "version": "5.10.0",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-6.0.0.tgz",
+      "integrity": "sha512-VHuCJ2W0YWFixGZh/l//8JiyOsD4gN+NhjdRAGIoUe0UQ4mtq1NyY2ZJ973XT+vYhaU21XdK8r8oNrd5n7wbzQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^6.0.0"
       }
     },
     "node_modules/@redis/time-series": {
-      "version": "5.10.0",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-6.0.0.tgz",
+      "integrity": "sha512-QWhkYsg+3lhBrBf+cbzybtV8LQcSrk7iXIgTaGU+pHNFTkql7TpVRE24ROS6M2ybVIV6O/zxTqfxgxxYiqyw0Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^6.0.0"
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -2969,7 +2993,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3817,7 +3843,9 @@
       }
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4065,6 +4093,8 @@
     },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -7844,7 +7874,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.2",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -7862,18 +7894,20 @@
       "license": "MIT"
     },
     "node_modules/redis": {
-      "version": "5.10.0",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-6.0.0.tgz",
+      "integrity": "sha512-n9Thfc39OXleEoPT2k5gwKsqY+HfCww3YS71ofcr9KKbkn89bpjU9dToIlD+JRdM3/GYQkwMtVgTxLyed+LptQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@redis/bloom": "5.10.0",
-        "@redis/client": "5.10.0",
-        "@redis/json": "5.10.0",
-        "@redis/search": "5.10.0",
-        "@redis/time-series": "5.10.0"
+        "@redis/bloom": "6.0.0",
+        "@redis/client": "6.0.0",
+        "@redis/json": "6.0.0",
+        "@redis/search": "6.0.0",
+        "@redis/time-series": "6.0.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -9418,7 +9452,7 @@
     },
     "packages/auth-clients": {
       "name": "@ministryofjustice/hmpps-auth-clients",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@ministryofjustice/hmpps-rest-client": "^1.2.1 || ^2.0.0"
@@ -9428,7 +9462,7 @@
         "@types/express": "^5.0.6",
         "@types/superagent": "^8.1.9",
         "nock": "14.0.14",
-        "redis": "^5.10.0"
+        "redis": "6.0.0"
       },
       "engines": {
         "node": "22 || 24 || 26"
@@ -9436,7 +9470,7 @@
     },
     "packages/azure-telemetry": {
       "name": "@ministryofjustice/hmpps-azure-telemetry",
-      "version": "0.0.1-alpha.4",
+      "version": "1.0.0",
       "license": "MIT",
       "engines": {
         "node": "22 || 24 || 26"
@@ -9514,10 +9548,10 @@
     },
     "packages/monitoring": {
       "name": "@ministryofjustice/hmpps-monitoring",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@ministryofjustice/hmpps-rest-client": "^1.2.1 || ^2.0.0"
+        "@ministryofjustice/hmpps-rest-client": "^2.1.0"
       },
       "bin": {
         "hmpps-monitoring": "bin/migrate.sh"
@@ -9536,7 +9570,7 @@
     },
     "packages/npm-script-allowlist": {
       "name": "@ministryofjustice/hmpps-npm-script-allowlist",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@npmcli/run-script": "10.0.4",
@@ -9565,7 +9599,7 @@
     },
     "packages/precommit-hooks": {
       "name": "@ministryofjustice/hmpps-precommit-hooks",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "bin": {
         "hmpps-precommit-hooks": "bin/init.sh",
@@ -9578,7 +9612,7 @@
     },
     "packages/rest-client": {
       "name": "@ministryofjustice/hmpps-rest-client",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "agentkeepalive": "^4.6.0",

--- a/packages/auth-clients/CHANGELOG.md
+++ b/packages/auth-clients/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 3.0.0
+
+Updates redis node library to version 6, which changes type definitions of the client class.
+Defaults to the `RESP3` protocol which servers 6+ support.
+
 ## 2.0.0
 
 Drops support for node engine 20 (no longer maintained) and adds 26 (will be LTS later this year).

--- a/packages/auth-clients/package.json
+++ b/packages/auth-clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-auth-clients",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Clients for authenticating and verifying tokens using the HMPPS Authentication estate",
   "author": "hmpps-developers",
   "license": "MIT",
@@ -37,7 +37,7 @@
     "@types/express": "^5.0.6",
     "@types/superagent": "^8.1.9",
     "nock": "14.0.14",
-    "redis": "^5.10.0"
+    "redis": "6.0.0"
   },
   "dependencies": {
     "@ministryofjustice/hmpps-rest-client": "^1.2.1 || ^2.0.0"

--- a/packages/auth-clients/src/main/types/RedisClient.ts
+++ b/packages/auth-clients/src/main/types/RedisClient.ts
@@ -1,3 +1,3 @@
-import type { createClient } from 'redis'
+import type { RedisClientType } from 'redis'
 
-export type RedisClient = ReturnType<typeof createClient>
+export type RedisClient = RedisClientType


### PR DESCRIPTION
The new Redis client defaults to the `RESP3` protocol which servers 6+ support.
This [can be changed back to the previous protocol](https://github.com/redis/node-redis/blob/redis@6.0.0/docs/v5-to-v6.md#if-you-need-to-preserve-v5-default-behavior-while-migrating-pin-resp2-explicitly) if a really old server is in use.

```typescript
createClient({ RESP: 2, … })
```