### PR TITLE
Enable log-sending from Bunyan to Azure to resolve missing AppTraces

### DIFF
--- a/packages/azure-telemetry/CHANGELOG.md
+++ b/packages/azure-telemetry/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 1.0.1
+
+Enables Bunyan log sending so application logs publish to the Azure Application Insights AppTraces table.
+
+## 1.0.0
+
+Bumped package version to 1.0.0 for initial production-ready release.
+
 ## 0.0.1-alpha.4
 
 Drops support for node engine 20 (no longer maintained) and adds 26 (will be LTS later this year).

--- a/packages/azure-telemetry/package.json
+++ b/packages/azure-telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-azure-telemetry",
-  "version": "0.0.1-alpha.4",
+  "version": "1.0.1",
   "description": "Azure Application Insights telemetry using OpenTelemetry",
   "author": "hmpps-developers",
   "license": "MIT",

--- a/packages/azure-telemetry/src/main/TelemetryInitialiser.ts
+++ b/packages/azure-telemetry/src/main/TelemetryInitialiser.ts
@@ -17,7 +17,7 @@ import { FilteringSpanProcessor } from './FilteringSpanProcessor'
 import { setConfig } from './config'
 
 export const defaultInstrumentations: Instrumentation[] = [
-  new BunyanInstrumentation({ disableLogSending: true }),
+  new BunyanInstrumentation({ disableLogSending: false }),
   new HttpInstrumentation(),
   new ExpressInstrumentation({
     ignoreLayersType: [ExpressLayerType.MIDDLEWARE, ExpressLayerType.ROUTER, ExpressLayerType.REQUEST_HANDLER],


### PR DESCRIPTION
- Set `disableLogSending` to `false` so that Bunyan does publish log details that make up AppTraces
- Bump package version to 1.0.1
