### PR TITLE
Handle custom timeout

### DIFF
--- a/packages/rest-client/CHANGELOG.md
+++ b/packages/rest-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+# 2.2.0
+
+Adds support for call-specific custom timeout
+
 # 2.1.0
 Allow client to be proxy-aware
  - keepalive agent options can be passed through to the underlying `agentkeepalive` agent configuration.

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-rest-client",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Standardized, reusable REST client for use with HMPPS services",
   "author": "hmpps-developers",
   "license": "MIT",

--- a/packages/rest-client/src/main/RestClient.test.ts
+++ b/packages/rest-client/src/main/RestClient.test.ts
@@ -125,6 +125,29 @@ describe('RestClient', () => {
       })
     })
 
+    it('should support a custom timeout when provided', async () => {
+      nock('http://localhost:8080', {
+        reqheaders: { authorization: 'Bearer some_system_jwt' },
+      })
+        [method]('/api/test')
+        .delay(250)
+        .reply(200, { success: true })
+
+      const result = await restClient[method](
+        {
+          path: '/test',
+          timeout: {
+            response: 300,
+            deadline: 350,
+          },
+        },
+        systemAuthOptions,
+      )
+
+      expect(nock.isDone()).toBe(true)
+      expect(result).toStrictEqual({ success: true })
+    })
+
     it('should support custom error handling when provided', async () => {
       nock('http://localhost:8080', {
         reqheaders: { authorization: 'Bearer some_system_jwt' },
@@ -621,6 +644,24 @@ describe('RestClient', () => {
 
       await expect(restClient.stream({ path: '/test-file' }, systemAuthOptions)).rejects.toThrow()
 
+      expect(nock.isDone()).toBe(true)
+    })
+
+    it('should support a custom timeout if provided', async () => {
+      nock('http://localhost:8080', {
+        reqheaders: { authorization: 'Bearer some_system_jwt' },
+      })
+        .get('/api/test-file')
+        .delay(250)
+        .reply(200, 'this is some file content', { 'Content-Type': 'application/x-zip-compressed' })
+
+      const readable = await restClient.stream(
+        { path: '/test-file', timeout: { response: 300, deadline: 350 } },
+        systemAuthOptions,
+      )
+      const receivedData = await readAll(readable)
+
+      expect(receivedData).toEqual('this is some file content')
       expect(nock.isDone()).toBe(true)
     })
   })

--- a/packages/rest-client/src/main/RestClient.ts
+++ b/packages/rest-client/src/main/RestClient.ts
@@ -154,6 +154,7 @@ export default class RestClient {
       responseType = '',
       raw = false,
       retries = 2,
+      timeout = this.timeoutConfig(),
       errorHandler = this.handleError,
       retryHandler = this.handleRetry,
     }: Request<Response, ErrorData>,
@@ -173,7 +174,7 @@ export default class RestClient {
         .retry(retries, retryHandler.bind(this)())
         .set(headers)
         .responseType(responseType)
-        .timeout(this.timeoutConfig())
+        .timeout(timeout)
 
       if (token) {
         req.auth(token, { type: 'bearer' })
@@ -209,6 +210,7 @@ export default class RestClient {
       files,
       raw = false,
       retry = false,
+      timeout = this.timeoutConfig(),
       errorHandler = this.handleError,
       retryHandler = this.handleRetry,
     }: RequestWithBody<Response, ErrorData>,
@@ -229,7 +231,7 @@ export default class RestClient {
           .retry(2, retryHandler.bind(this)(retry))
           .set(headers)
           .responseType(responseType)
-          .timeout(this.timeoutConfig())
+          .timeout(timeout)
 
         if (multipartData) {
           Object.entries(multipartData).forEach(([key, value]) => {
@@ -250,7 +252,7 @@ export default class RestClient {
           .retry(2, retryHandler.bind(this)(retry))
           .set(headers)
           .responseType(responseType)
-          .timeout(this.timeoutConfig())
+          .timeout(timeout)
       }
 
       if (token) {
@@ -330,6 +332,7 @@ export default class RestClient {
       responseType = '',
       raw = false,
       retries = 2,
+      timeout = this.timeoutConfig(),
       errorHandler = this.handleError,
       retryHandler = this.handleRetry,
     }: Request<Response, ErrorData>,
@@ -347,7 +350,7 @@ export default class RestClient {
         .retry(retries, retryHandler.bind(this)())
         .set(headers)
         .responseType(responseType)
-        .timeout(this.timeoutConfig())
+        .timeout(timeout)
 
       if (token) {
         req.auth(token, { type: 'bearer' })
@@ -370,7 +373,7 @@ export default class RestClient {
    *          type SanitisedError<ErrorData>.
    */
   async stream<ErrorData = unknown>(
-    { path, headers = {}, errorLogger = this.logError }: StreamRequest<ErrorData>,
+    { path, headers = {}, errorLogger = this.logError, timeout = this.timeoutConfig() }: StreamRequest<ErrorData>,
     authOptions?: AuthOptions | string,
   ): Promise<Readable> {
     this.logger.debug(`${this.name} streaming: ${path}`)
@@ -382,7 +385,7 @@ export default class RestClient {
         .get(`${this.apiUrl()}${path}`)
         .agent(this.agent)
         .retry(2, this.handleRetry())
-        .timeout(this.timeoutConfig())
+        .timeout(timeout)
         .set(headers)
 
       if (token) {

--- a/packages/rest-client/src/main/types/Request.ts
+++ b/packages/rest-client/src/main/types/Request.ts
@@ -2,6 +2,7 @@ import type superagent from 'superagent'
 import type http from 'http'
 import { Response as SuperAgentResponse } from 'superagent'
 import { ErrorHandler, ErrorLogger } from './Errors'
+import { type ApiConfig } from './ApiConfig'
 
 export interface Request<Response, ErrorData> {
   path: string
@@ -9,6 +10,7 @@ export interface Request<Response, ErrorData> {
   headers?: Record<string, string>
   responseType?: string
   retries?: number
+  timeout?: ApiConfig['timeout']
   raw?: boolean
   errorHandler?: ErrorHandler<Response, ErrorData>
   retryHandler?: (retry?: boolean) => (err: Error, res: SuperAgentResponse) => boolean | undefined
@@ -46,6 +48,7 @@ export interface StreamRequest<ErrorData> {
   path: string
   headers?: Record<string, string>
   errorLogger?: ErrorLogger<ErrorData>
+  timeout?: ApiConfig['timeout']
 }
 
 export interface CallContext {


### PR DESCRIPTION
This PR provides the ability to define a custom timeout for a given REST call (any method, also includes stream):

```typescript
class ExampleApiClient extends RestClient {
  constructor() {
    super(
      'example-api',
      {
        url: 'https://example.com/api',
        timeout: {
          response: 5000,
          deadline: 10000,
        },
        agent: { maxSockets: 100 },
      } as ApiConfig,
      console, // Replace with a proper logger in production
      {
        getToken: async () => 'your-system-token', // Replace with a token management strategy
      },
    )
  }

  async getExampleDataWithDefaultTimeout(username: string) {
    return this.get({ path: '/fast-endpoint' }, asSystem(username))
  }

  async getExampleDataWithCustomTimeout(username: string) {
    return this.get({ 
      path: '/slow-endpoint', 
      timeout: {
        response: 20000,
        deadline: 25000,
      },
    }, asSystem(username))
  }

```

The `timeout` uses the same type as the `ApiConfig` property for simplicity. This could be extended to allow a single number as SuperAgent also allows this!