### PR TITLE
Populate operation name for log entries in AppTraces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9398,7 +9398,7 @@
         "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.32",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/api-logs": "0.214.0",
-        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/core": ">=2.5.1 <3",
         "@opentelemetry/instrumentation": "0.212.0",
         "@opentelemetry/instrumentation-bunyan": "0.58.0",
         "@opentelemetry/instrumentation-express": "0.59.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
     "node_modules/@azure/abort-controller": {
       "version": "2.1.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -49,7 +48,6 @@
     "node_modules/@azure/core-auth": {
       "version": "1.10.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-util": "^1.13.0",
@@ -62,7 +60,6 @@
     "node_modules/@azure/core-client": {
       "version": "1.10.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -79,7 +76,6 @@
     "node_modules/@azure/core-rest-pipeline": {
       "version": "1.22.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -96,7 +92,6 @@
     "node_modules/@azure/core-tracing": {
       "version": "1.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -107,7 +102,6 @@
     "node_modules/@azure/core-util": {
       "version": "1.13.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@typespec/ts-http-runtime": "^0.3.0",
@@ -120,7 +114,6 @@
     "node_modules/@azure/logger": {
       "version": "1.3.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
@@ -132,7 +125,6 @@
     "node_modules/@azure/monitor-opentelemetry-exporter": {
       "version": "1.0.0-beta.32",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/core-auth": "^1.9.0",
         "@azure/core-client": "^1.9.2",
@@ -154,7 +146,6 @@
     "node_modules/@azure/monitor-opentelemetry-exporter/node_modules/@opentelemetry/api-logs": {
       "version": "0.200.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
@@ -165,7 +156,6 @@
     "node_modules/@azure/monitor-opentelemetry-exporter/node_modules/@opentelemetry/core": {
       "version": "2.0.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -179,7 +169,6 @@
     "node_modules/@azure/monitor-opentelemetry-exporter/node_modules/@opentelemetry/resources": {
       "version": "2.0.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -194,7 +183,6 @@
     "node_modules/@azure/monitor-opentelemetry-exporter/node_modules/@opentelemetry/sdk-logs": {
       "version": "0.200.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.200.0",
         "@opentelemetry/core": "2.0.0",
@@ -232,6 +220,7 @@
       "version": "7.28.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1659,7 +1648,6 @@
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "2.5.1",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -1684,7 +1672,6 @@
     "node_modules/@opentelemetry/instrumentation": {
       "version": "0.212.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.212.0",
         "import-in-the-middle": "^2.0.6",
@@ -1700,7 +1687,6 @@
     "node_modules/@opentelemetry/instrumentation-bunyan": {
       "version": "0.58.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "^0.213.0",
         "@opentelemetry/instrumentation": "^0.213.0",
@@ -1716,7 +1702,6 @@
     "node_modules/@opentelemetry/instrumentation-bunyan/node_modules/@opentelemetry/api-logs": {
       "version": "0.213.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
@@ -1727,7 +1712,6 @@
     "node_modules/@opentelemetry/instrumentation-bunyan/node_modules/@opentelemetry/instrumentation": {
       "version": "0.213.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.213.0",
         "import-in-the-middle": "^3.0.0",
@@ -1743,7 +1727,6 @@
     "node_modules/@opentelemetry/instrumentation-bunyan/node_modules/import-in-the-middle": {
       "version": "3.0.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-import-attributes": "^1.9.5",
@@ -1757,7 +1740,6 @@
     "node_modules/@opentelemetry/instrumentation-express": {
       "version": "0.59.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -1773,7 +1755,6 @@
     "node_modules/@opentelemetry/instrumentation-express/node_modules/@opentelemetry/api-logs": {
       "version": "0.211.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
@@ -1784,7 +1765,6 @@
     "node_modules/@opentelemetry/instrumentation-express/node_modules/@opentelemetry/instrumentation": {
       "version": "0.211.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.211.0",
         "import-in-the-middle": "^2.0.0",
@@ -1817,7 +1797,6 @@
     "node_modules/@opentelemetry/instrumentation/node_modules/@opentelemetry/api-logs": {
       "version": "0.212.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
@@ -1845,7 +1824,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.215.0.tgz",
       "integrity": "sha512-y3ucOmphzc4vgBTyIGchs+N/1rkACmoka8QalT2z1LBNM232Z17zMYayHcMl+dgMoOadZ0b72UZv7mDtqy1cFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.215.0",
         "@opentelemetry/core": "2.7.0",
@@ -1864,7 +1842,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.215.0.tgz",
       "integrity": "sha512-xrFlqhdhUyO8wSRn6DjE0145/HPWSJ5Nm0C7vWua6TdL/FSEAZvEyvdsa9CRXuxo9ebb7j/NEPhEcO62IJ0qUA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
@@ -1877,7 +1854,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
       "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -1893,7 +1869,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
       "integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -1908,7 +1883,6 @@
     "node_modules/@opentelemetry/sdk-metrics": {
       "version": "2.5.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.1",
         "@opentelemetry/resources": "2.5.1"
@@ -2005,6 +1979,7 @@
       "integrity": "sha512-NS4iIT25r24sAjNQ2nSRdCW5jPJoV0rxkBee27oTeR+RXaOu89cjIsrww5rPBaYVGVdL1QCx9uz9141gZiSKdQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -2247,9 +2222,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2264,9 +2236,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2281,9 +2250,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2298,9 +2264,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2315,9 +2278,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2332,9 +2292,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2349,9 +2306,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2366,9 +2320,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2383,9 +2334,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2400,9 +2348,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2417,9 +2362,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2434,9 +2376,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2451,9 +2390,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2860,6 +2796,7 @@
     "node_modules/@typescript-eslint/parser": {
       "version": "8.56.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3076,7 +3013,6 @@
     "node_modules/@typespec/ts-http-runtime": {
       "version": "0.3.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.0",
@@ -3187,9 +3123,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3202,9 +3135,6 @@
       "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3219,9 +3149,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3234,9 +3161,6 @@
       "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3251,9 +3175,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3266,9 +3187,6 @@
       "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3283,9 +3201,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3298,9 +3213,6 @@
       "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3386,6 +3298,7 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3396,7 +3309,6 @@
     "node_modules/acorn-import-attributes": {
       "version": "1.9.5",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -3418,6 +3330,7 @@
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "humanize-ms": "^1.2.1"
       },
@@ -3777,6 +3690,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -4553,6 +4467,7 @@
     "node_modules/eslint": {
       "version": "9.39.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4633,6 +4548,7 @@
     "node_modules/eslint-config-prettier": {
       "version": "10.1.8",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4767,6 +4683,7 @@
     "node_modules/eslint-plugin-import": {
       "version": "2.32.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5281,8 +5198,7 @@
     },
     "node_modules/forwarded-parse": {
       "version": "2.1.2",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fs-minipass": {
       "version": "3.0.3",
@@ -5516,6 +5432,7 @@
       "version": "6.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -5741,7 +5658,6 @@
     "node_modules/import-in-the-middle": {
       "version": "2.0.6",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-import-attributes": "^1.9.5",
@@ -6300,6 +6216,7 @@
       "version": "30.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -7233,8 +7150,7 @@
     },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/moment": {
       "version": "2.30.1",
@@ -7781,6 +7697,7 @@
     "node_modules/prettier": {
       "version": "3.8.1",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7959,7 +7876,6 @@
     "node_modules/require-in-the-middle": {
       "version": "8.0.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.3.5",
         "module-details-from-path": "^1.0.3"
@@ -8023,6 +7939,7 @@
       "version": "4.60.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9009,6 +8926,7 @@
     "node_modules/typescript": {
       "version": "5.9.3",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9073,6 +8991,7 @@
       "version": "1.11.1",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -9470,7 +9389,7 @@
     },
     "packages/azure-telemetry": {
       "name": "@ministryofjustice/hmpps-azure-telemetry",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "engines": {
         "node": "22 || 24 || 26"
@@ -9479,6 +9398,7 @@
         "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.32",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.5.1",
         "@opentelemetry/instrumentation": "0.212.0",
         "@opentelemetry/instrumentation-bunyan": "0.58.0",
         "@opentelemetry/instrumentation-express": "0.59.0",
@@ -9612,7 +9532,7 @@
     },
     "packages/rest-client": {
       "name": "@ministryofjustice/hmpps-rest-client",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "agentkeepalive": "^4.6.0",

--- a/packages/azure-telemetry/CHANGELOG.md
+++ b/packages/azure-telemetry/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.2
 
-Populate operation name (HTTP method + route) in Bunyan logs so this available in AppTraces table.
+Populate operation name (HTTP method + route) in Bunyan logs so this is available in AppTraces table.
 
 ## 1.0.1
 

--- a/packages/azure-telemetry/CHANGELOG.md
+++ b/packages/azure-telemetry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 1.0.2
+
+Populate operation name (HTTP method + route) in Bunyan logs so this available in AppTraces table.
+
 ## 1.0.1
 
 Enables Bunyan log sending so application logs publish to the Azure Application Insights AppTraces table.

--- a/packages/azure-telemetry/package.json
+++ b/packages/azure-telemetry/package.json
@@ -35,8 +35,8 @@
   "peerDependencies": {
     "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.32",
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/core": "2.5.1",
     "@opentelemetry/api-logs": "0.214.0",
+    "@opentelemetry/core": ">=2.5.1 <3",
     "@opentelemetry/instrumentation": "0.212.0",
     "@opentelemetry/instrumentation-bunyan": "0.58.0",
     "@opentelemetry/instrumentation-express": "0.59.0",

--- a/packages/azure-telemetry/package.json
+++ b/packages/azure-telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-azure-telemetry",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Azure Application Insights telemetry using OpenTelemetry",
   "author": "hmpps-developers",
   "license": "MIT",
@@ -35,6 +35,7 @@
   "peerDependencies": {
     "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.32",
     "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/core": "2.5.1",
     "@opentelemetry/api-logs": "0.214.0",
     "@opentelemetry/instrumentation": "0.212.0",
     "@opentelemetry/instrumentation-bunyan": "0.58.0",

--- a/packages/azure-telemetry/src/main/TelemetryInitialiser.ts
+++ b/packages/azure-telemetry/src/main/TelemetryInitialiser.ts
@@ -14,10 +14,11 @@ import { AzureMonitorLogExporter, AzureMonitorTraceExporter } from '@azure/monit
 import type { TelemetryConfig } from './types/TelemetryConfig'
 import type { SpanFilterFn, SpanModifierFn } from './types/SpanProcessor'
 import { FilteringSpanProcessor } from './FilteringSpanProcessor'
+import { populateOperationNameLogHook } from './populateOperationNameLogHook'
 import { setConfig } from './config'
 
 export const defaultInstrumentations: Instrumentation[] = [
-  new BunyanInstrumentation({ disableLogSending: false }),
+  new BunyanInstrumentation({ disableLogSending: false, logHook: populateOperationNameLogHook }),
   new HttpInstrumentation(),
   new ExpressInstrumentation({
     ignoreLayersType: [ExpressLayerType.MIDDLEWARE, ExpressLayerType.ROUTER, ExpressLayerType.REQUEST_HANDLER],

--- a/packages/azure-telemetry/src/main/index.ts
+++ b/packages/azure-telemetry/src/main/index.ts
@@ -6,6 +6,7 @@ import { modifySpanWithObfuscation } from './processors/modifySpanWithObfuscatio
 
 /** Export types */
 export { initialiseTelemetry, flushTelemetry, defaultInstrumentations, trace } from './TelemetryInitialiser'
+export { populateOperationNameLogHook } from './populateOperationNameLogHook'
 export type { TelemetryBuilder } from './TelemetryInitialiser'
 export type { SpanInfo, ModifiableSpan, SpanFilterFn, SpanModifierFn } from './types/SpanProcessor'
 export type { TelemetryConfig } from './types/TelemetryConfig'

--- a/packages/azure-telemetry/src/main/populateOperationNameLogHook.test.ts
+++ b/packages/azure-telemetry/src/main/populateOperationNameLogHook.test.ts
@@ -1,0 +1,90 @@
+import { getRPCMetadata } from '@opentelemetry/core'
+import type { Span } from '@opentelemetry/api'
+
+import { populateOperationNameLogHook } from './populateOperationNameLogHook'
+
+jest.mock('@azure/monitor-opentelemetry-exporter', () => ({
+  AI_OPERATION_NAME: 'ai.operation.name',
+}))
+
+jest.mock('@opentelemetry/api', () => ({
+  context: {
+    active: jest.fn(),
+  },
+}))
+
+jest.mock('@opentelemetry/core', () => ({
+  getRPCMetadata: jest.fn(),
+}))
+
+const AI_OPERATION_NAME = 'ai.operation.name'
+
+const mockGetRPCMetadata = getRPCMetadata as jest.Mock
+
+function createMockSpan(attributes?: Record<string, string>): Record<string, unknown> {
+  return {
+    attributes,
+  }
+}
+
+describe('populateOperationNameLogHook()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should set the operation name when method and route are available', () => {
+    const span = createMockSpan({
+      'http.request.method': 'GET',
+    })
+    const record: Record<string, string> = {}
+    mockGetRPCMetadata.mockReturnValue({ route: '/users/:id' })
+
+    populateOperationNameLogHook(span as unknown as Span, record)
+
+    expect(record).toEqual({ [AI_OPERATION_NAME]: 'GET /users/:id' })
+  })
+
+  it('should fall back to http.method when http.request.method is not set', () => {
+    const span = createMockSpan({
+      'http.method': 'POST',
+    })
+    const record: Record<string, string> = {}
+    mockGetRPCMetadata.mockReturnValue({ route: '/api/submit' })
+
+    populateOperationNameLogHook(span as unknown as Span, record)
+
+    expect(record).toEqual({ [AI_OPERATION_NAME]: 'POST /api/submit' })
+  })
+
+  it('should not set operation name when route is missing', () => {
+    const span = createMockSpan({
+      'http.request.method': 'GET',
+    })
+    const record: Record<string, string> = {}
+    mockGetRPCMetadata.mockReturnValue({})
+
+    populateOperationNameLogHook(span as unknown as Span, record)
+
+    expect(record).toEqual({})
+  })
+
+  it('should not set operation name when method is missing', () => {
+    const span = createMockSpan()
+    const record: Record<string, string> = {}
+    mockGetRPCMetadata.mockReturnValue({ route: '/users/:id' })
+
+    populateOperationNameLogHook(span as unknown as Span, record)
+
+    expect(record).toEqual({})
+  })
+
+  it('should not set operation name when both method and route are missing', () => {
+    const span = createMockSpan()
+    const record: Record<string, string> = {}
+    mockGetRPCMetadata.mockReturnValue({})
+
+    populateOperationNameLogHook(span as unknown as Span, record)
+
+    expect(record).toEqual({})
+  })
+})

--- a/packages/azure-telemetry/src/main/populateOperationNameLogHook.ts
+++ b/packages/azure-telemetry/src/main/populateOperationNameLogHook.ts
@@ -1,0 +1,22 @@
+import { context } from '@opentelemetry/api'
+import { getRPCMetadata } from '@opentelemetry/core'
+import { LogHookFunction } from '@opentelemetry/instrumentation-bunyan'
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
+import { AI_OPERATION_NAME } from '@azure/monitor-opentelemetry-exporter'
+
+/**
+ * Log hook that populates the operation name in log records from HTTP spans.
+ *
+ * Extracts the HTTP method from span attributes and the route template from RPC metadata,
+ * then sets the operation name to `${method} ${route}` (e.g., "GET /users/:id").
+ */
+export const populateOperationNameLogHook: LogHookFunction = (span, record) => {
+  const readableSpan = span as unknown as ReadableSpan
+
+  const method = readableSpan.attributes?.['http.request.method'] ?? readableSpan.attributes?.['http.method']
+  const route = getRPCMetadata(context.active())?.route
+
+  if (method && route) {
+    Object.assign(record, { [AI_OPERATION_NAME]: `${method} ${route}` })
+  }
+}


### PR DESCRIPTION
* Populate operation name (HTTP method + route, e.g. `GET /user/:id`) in Bunyan logs so this available in AppTraces table.
* Bump version to 1.0.2