### PR TITLE
Bump version of devsecops-hooks image used in precommit-hooks module

### DIFF
--- a/packages/precommit-hooks/CHANGELOG.md
+++ b/packages/precommit-hooks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 3.0.2
+
+Bump version of `devsecops-hooks` to v2.0.2
+
 ## 3.0.1
 
 Excludes snapshot test files from trailing-whitespace hook

--- a/packages/precommit-hooks/README.md
+++ b/packages/precommit-hooks/README.md
@@ -46,11 +46,11 @@ HMPPS_HOOKS_VERSION: 1
 
 repos:
   - repo: https://github.com/ministryofjustice/devsecops-hooks
-    rev: v1.4.1
+    rev: v2.0.2
     hooks:
       - id: baseline
         env:
-          GITLEAKS_CONFIGURATION_FILE: ./.gitleaks/gitleaks.toml
+          GITLEAKS_CONFIGURATION_FILE: ./.gitleaks/config.toml
           GITLEAKS_IGNORE_FILE: ./.gitleaks/.gitleaksignore
 
   - repo: local
@@ -58,19 +58,29 @@ repos:
       - id: lint
         name: linting code
         language: system
-        entry: npm run lint
+        entry: ./node_modules/.bin/lint-staged
+        files: (\.(ts|js|css)$|^package-lock\.json$)
+        require_serial: true
+        pass_filenames: false
       - id: typecheck
         name: verify types
         language: system
         entry: npm run typecheck
+        files: (\.(ts)$|^package-lock\.json$)
+        require_serial: true
+        pass_filenames: false
       - id: test
         name: running tests
         language: system
         entry: npm run test
+        files: (\.(ts)$|^package-lock\.json$)
+        require_serial: true
+        pass_filenames: false
   - repo: builtin
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+        exclude: ^.*snap$
       - id: check-json
       - id: check-yaml
       - id: check-merge-conflict

--- a/packages/precommit-hooks/default-hooks.yaml
+++ b/packages/precommit-hooks/default-hooks.yaml
@@ -6,7 +6,7 @@
 
 repos:
   - repo: https://github.com/ministryofjustice/devsecops-hooks
-    rev: v1.4.1
+    rev: v2.0.2
     hooks:
       - id: baseline
         env:

--- a/packages/precommit-hooks/package.json
+++ b/packages/precommit-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-precommit-hooks",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Precommit hooks for HMPPS typescript projects",
   "keywords": [
     "precommit"


### PR DESCRIPTION
Also update the `README.md` with current `default-hooks.yaml` content.