### PR TITLE
make sqs audit logging debug level to reduce log noise in production envs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11154,7 +11154,7 @@
     },
     "packages/audit-client": {
       "name": "@ministryofjustice/hmpps-audit-client",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.1092.0",

--- a/packages/audit-client/CHANGELOG.md
+++ b/packages/audit-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 2.0.0-beta.3
+
+SQS Audit logging was set to INFO resulting in verbose and noisy logging in prod environments with high volume usage of audited journeys. Reduced to DEBUG. 
+
 ## 2.0.0-beta.2
 
 NO_PROXY was being ignored, this has been addressed so it is now also respected and enforced

--- a/packages/audit-client/package.json
+++ b/packages/audit-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-audit-client",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "Client for sending audit events to HMPPS Audit API",
   "author": "hmpps-developers",
   "license": "MIT",

--- a/packages/audit-client/src/main/AuditClient.ts
+++ b/packages/audit-client/src/main/AuditClient.ts
@@ -153,7 +153,7 @@ export default class HmppsAuditClient {
         new SendMessageCommand({ MessageBody: JSON.stringify(sqsMessage), QueueUrl: this.queueUrl }),
       )
 
-      this.logger.info(`HMPPS Audit SQS message sent (${messageResponse.MessageId})`)
+      this.logger.debug(`HMPPS Audit SQS message sent (${messageResponse.MessageId})`)
 
       return messageResponse
     } catch (error) {


### PR DESCRIPTION
Proposal to reduce the audit logging to DEBUG level. 